### PR TITLE
Bump version number to latest.

### DIFF
--- a/bin/configs.js
+++ b/bin/configs.js
@@ -1,6 +1,6 @@
 export const metadata = {
   name: "Quick Start Express",
-  version: "v1.0.3-beta",
+  version: "v1.0.4-beta",
   description:
     "A simple CLI tool to generate Express servers from multiple available templates.",
   oneLineDescription: "A simple Express.js server generator CLI tool.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qse",
-  "version": "1.0.3-beta",
+  "version": "1.0.4-beta",
   "description": "A simple CLI tool to generate Express servers from multiple available templates.",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
- [x] Bump version number to `v1.0.4-beta`.

Fixes https://github.com/CSE-25/quick_start_express/issues/16.