### PR TITLE
Add content check tests for init command.

### DIFF
--- a/test/init.test.js
+++ b/test/init.test.js
@@ -81,14 +81,14 @@ describe('init', () => {
         await exec(`node ../../bin/index.js init -t express_pg_sequelize`, { cwd: tempDir });
         const commandHash = computeSHA256Hash(tempDir);
         expect(commandHash).toEqual(originalHash);
-    });
+    }, 10000);
 
     test('express_mysql', async () => {
         const originalHash = computeSHA256Hash(path.join(__dirname, '..', 'templates', 'express_mysql'));
         await exec(`node ../../bin/index.js init -t express_mysql`, { cwd: tempDir });
         const commandHash = computeSHA256Hash(tempDir);
         expect(commandHash).toEqual(originalHash);
-    });
+    }, 10000);
 
     test('invalid template name passed', async () => {
         const { stdout, stderr } = await exec(`node ../../bin/index.js init -t invalid_name`, { cwd: tempDir });

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -1,0 +1,92 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const util = require('node:util');
+const exec = util.promisify(require('node:child_process').exec);
+const tempDir = path.join(__dirname, 'temp');
+
+function initTempDirectory() {
+    if (fs.existsSync(tempDir)) {
+        fs.rmSync(tempDir, { recursive: true });
+    }
+    fs.mkdirSync(tempDir);
+}
+
+function clearTempDirectory() {
+    if (fs.existsSync(tempDir)) {
+        fs.rmSync(tempDir, { recursive: true });
+    }
+}
+
+function traverseDirectory(dirName) {
+    const files = fs.readdirSync(dirName);
+
+    for (const file of files) {
+        const filePath = path.join(dirName, file);
+        const stats = fs.statSync(filePath);
+        if (stats.isDirectory()) {
+            traverseDirectory(filePath);
+        }
+    }
+}
+
+// Ignore node_modules and package-lock.json
+// and compute the SHA256 hash.
+function computeSHA256Hash(dirName) {
+    const hash = crypto.createHash('sha256');
+    const files = fs.readdirSync(dirName);
+
+    for (const file of files) {
+        if (file === 'node_modules' || file === 'package-lock.json' || file === 'package.json') {
+            continue;
+        }
+        const filePath = path.join(dirName, file);
+        const stats = fs.statSync(filePath);
+        if (stats.isDirectory()) {
+            traverseDirectory(filePath);
+        } else {
+            const data = fs.readFileSync(filePath);
+            hash.update(data);
+        }
+    }
+
+    return hash.digest('hex');
+}
+
+describe('init', () => {
+    beforeEach(() => {
+        initTempDirectory();
+    });    
+
+    afterAll(() => {
+        clearTempDirectory();
+    });
+
+    test('no templates passed, should default to basic', async () => {
+        const originalHash = computeSHA256Hash(path.join(__dirname, '..', 'templates', 'basic'));
+        await exec(`node ../../bin/index.js init`, { cwd: tempDir });
+        const commandHash = computeSHA256Hash(tempDir);
+        expect(commandHash).toEqual(originalHash);
+    })
+
+    test('basic', async () => {
+        const originalHash = computeSHA256Hash(path.join(__dirname, '..', 'templates', 'basic'));
+        await exec(`node ../../bin/index.js init -t basic`, { cwd: tempDir });
+        const commandHash = computeSHA256Hash(tempDir);
+        expect(commandHash).toEqual(originalHash);
+    });
+
+    test('express_pg_sequelize', async () => {
+        const originalHash = computeSHA256Hash(path.join(__dirname, '..', 'templates', 'express_pg_sequelize'));
+        await exec(`node ../../bin/index.js init -t express_pg_sequelize`, { cwd: tempDir });
+        const commandHash = computeSHA256Hash(tempDir);
+        expect(commandHash).toEqual(originalHash);
+    });
+
+    test('express_mysql', async () => {
+        const originalHash = computeSHA256Hash(path.join(__dirname, '..', 'templates', 'express_mysql'));
+        await exec(`node ../../bin/index.js init -t express_mysql`, { cwd: tempDir });
+        const commandHash = computeSHA256Hash(tempDir);
+        expect(commandHash).toEqual(originalHash);
+    });
+});

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -18,14 +18,17 @@ function clearTempDirectory() {
     }
 }
 
-function traverseDirectory(dirName) {
+function traverseDirectory(dirName, hash) {
     const files = fs.readdirSync(dirName);
 
     for (const file of files) {
         const filePath = path.join(dirName, file);
         const stats = fs.statSync(filePath);
         if (stats.isDirectory()) {
-            traverseDirectory(filePath);
+            traverseDirectory(filePath, hash);
+        } else {
+            const data = fs.readFileSync(filePath);
+            hash.update(data);
         }
     }
 }
@@ -43,7 +46,7 @@ function computeSHA256Hash(dirName) {
         const filePath = path.join(dirName, file);
         const stats = fs.statSync(filePath);
         if (stats.isDirectory()) {
-            traverseDirectory(filePath);
+            traverseDirectory(filePath, hash);
         } else {
             const data = fs.readFileSync(filePath);
             hash.update(data);

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -89,4 +89,9 @@ describe('init', () => {
         const commandHash = computeSHA256Hash(tempDir);
         expect(commandHash).toEqual(originalHash);
     });
+
+    test('invalid template name passed', async () => {
+        const { stdout, stderr } = await exec(`node ../../bin/index.js init -t invalid_name`, { cwd: tempDir });
+        expect(stderr).toContain(`Template invalid_name does not exist. To see available templates use "qse list".`);
+    });
 });


### PR DESCRIPTION
## Updates to test

- [x] New test file `init.test.js` added.
- [x] For all the 3 available templates, added test code that will check if the files have a matching sha256 checksum.
- [x] Added a test case that checks if an error is printed to the console on invalid template name being provided.

## Future work

- [ ] Add test code to test API endpoints generated by the command for all 3 templates.



>[!Important]
>Help needed to optimize code. It takes > 5 seconds per test causing timeouts. One possible optimization I thought of was to precompute the SHA256 hashes of the templates so that we can increase the speed by 50%. But need suggestions for more dynamic ideas.

![image](https://github.com/user-attachments/assets/d2e49bc0-4e9d-4303-b872-f7264fa0045d)



Fixes https://github.com/CSE-25/quick_start_express/issues/25
