### PR TITLE
feat: add -n option to customize package name during initialization

### DIFF
--- a/bin/configs.js
+++ b/bin/configs.js
@@ -39,61 +39,11 @@ export const commands = {
 export const templates = {
   basic: {
     name: "basic",
-    dependencies: [
-      {
-        name: "express",
-        version: "^4.17.1",
-      },
-    ],
   },
   express_pg_sequelize: {
     name: "express_pg_sequelize",
-    dependencies: [
-      {
-        name: "express",
-        version: "^4.17.1",
-      },
-      {
-        name: "pg",
-        version: "^8.6.0",
-      },
-      {
-        name: "pg-hstore",
-        version: "^2.3.4",
-      },
-      {
-        name: "sequelize",
-        version: "^6.6.5",
-      },
-      {
-        name: "dotenv",
-        version: "^16.4.1",
-      },
-    ],
   },
   express_mysql: {
     name: "express_mysql",
-    dependencies: [
-      {
-        name: "express",
-        version: "^4.17.1",
-      },
-      {
-        name: "cors",
-        version: "^2.8.5",
-      },
-      {
-        name: "fs",
-        version: "^0.0.1-security",
-      },
-      {
-        name: "helmet",
-        version: "^8.0.0",
-      },
-      {
-        name: "mysql2",
-        version: "^3.11.3",
-      },
-    ],
   },
 };

--- a/bin/configs.js
+++ b/bin/configs.js
@@ -20,6 +20,10 @@ export const commands = {
         flags: "-t, --template <template>",
         description: "Specify template to use",
       },
+      {
+        flags: "-n, --name <name>",
+        description: "Specify the name of the package",
+      },
     ],
   },
   list: {

--- a/bin/index.js
+++ b/bin/index.js
@@ -115,7 +115,9 @@ function initCommand(options) {
   if (!templates[selectedTemplate]) {
     console.error(
       chalk.red(
-        `Template ${selectedTemplate} does not exist. To see available templates use ${chalk.yellow(
+        `Template ${chalk.bgRed.bold(
+          selectedTemplate
+        )} does not exist. To see available templates use ${chalk.yellow(
           '"qse list"'
         )}.`
       )

--- a/bin/index.js
+++ b/bin/index.js
@@ -13,7 +13,7 @@ import validate from "validate-npm-package-name";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const parentDir = path.join(__dirname, "..");
+const parentDir = path.dirname(__dirname);
 
 program
   .name(metadata.command)
@@ -122,7 +122,7 @@ async function initCommand(options) {
   console.log("Starting server initialization...");
 
   const targetDir = process.cwd();
-  const templatePath = path.join(parentDir, "templates", selectedTemplate);
+  const templatePath = path.join(parentDir, "templates", templates[selectedTemplate].name);
 
   const destinationPath = path.join(targetDir);
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -13,6 +13,7 @@ import validate from "validate-npm-package-name";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+const parentDir = path.join(__dirname, "..");
 
 program
   .name(metadata.command)
@@ -121,7 +122,7 @@ async function initCommand(options) {
   console.log("Starting server initialization...");
 
   const targetDir = process.cwd();
-  const templatePath = path.join(__dirname, "../templates", selectedTemplate);
+  const templatePath = path.join(parentDir, "templates", selectedTemplate);
 
   const destinationPath = path.join(targetDir);
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -95,20 +95,13 @@ function initCommand(options) {
   if (packageName) {
     const validateResult = validate(packageName);
     if (validateResult.validForNewPackages === false) {
-      if (validateResult.errors) {
+        const errors = validateResult.errors || validateResult.warnings;
         console.error(
-          chalk.red.bold(
-            `Invalid package name: ${validateResult.errors}. Please provide a valid package name.`
-          )
+        chalk.red.bold(
+            `Invalid package name: ${errors.join(", ")}. Please provide a valid package name.`
+        )
         );
-      } else if (validateResult.warnings) {
-        console.error(
-          chalk.red.bold(
-            `Invalid package name: ${validateResult.warnings}. Please provide a valid package name.`
-          )
-        );
-      }
-      return;
+        return;
     }
   }
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -22,6 +22,7 @@ program
   .command(commands.init.command)
   .description(commands.init.description)
   .option(commands.init.options[0].flags, commands.init.options[0].description)
+  .option(commands.init.options[1].flags, commands.init.options[1].description)
   .action((options) => {
     toolIntro();
     initCommand(options);
@@ -35,12 +36,20 @@ program
     Object.keys(commands).forEach((cmd) => {
       const commandInfo = commands[cmd];
       if (commandInfo.command) {
-        console.log(`- ${commandInfo.command}${commandInfo.description ? ": " + commandInfo.description : ""}`);
+        console.log(
+          `- ${commandInfo.command}${
+            commandInfo.description ? ": " + commandInfo.description : ""
+          }`
+        );
       }
 
       if (commandInfo.options) {
         commandInfo.options.forEach((option) => {
-          console.log(`  (Options: ${option.flags}${option.description ? " - " + option.description : ""})`);
+          console.log(
+            `  (Options: ${option.flags}${
+              option.description ? " - " + option.description : ""
+            })`
+          );
         });
       }
     });
@@ -80,9 +89,14 @@ program
 
 function initCommand(options) {
   const selectedTemplate = options.template || "basic"; // Default to 'basic' if no template is specified
+  const packageName = options.name || "quick-start-express-server"; // Default to 'quick-start-express-server' if no name is specified
 
   if (!templates[selectedTemplate]) {
-    console.error(chalk.bgRed.white(`Template ${selectedTemplate} does not exist. To see available templates use "qse list".`));
+    console.error(
+      chalk.bgRed.white(
+        `Template ${selectedTemplate} does not exist. To see available templates use "qse list".`
+      )
+    );
     return;
   }
 
@@ -90,7 +104,11 @@ function initCommand(options) {
 
   const targetDir = process.cwd();
   const parentDir = path.dirname(__dirname);
-  const templatePath = path.join(parentDir, "templates", templates[selectedTemplate].name);
+  const templatePath = path.join(
+    parentDir,
+    "templates",
+    templates[selectedTemplate].name
+  );
   const destinationPath = path.join(targetDir);
   const npmInit = chalk.yellow.bold("npm init");
 
@@ -98,6 +116,12 @@ function initCommand(options) {
   const initSpinner = createSpinner(`Running ${npmInit}...`).start();
   try {
     execSync("npm init -y", { stdio: "ignore", cwd: targetDir });
+
+    const packageJsonPath = path.join(targetDir, "package.json");
+    const packageJsonContent = fs.readFileSync(packageJsonPath, "utf8");
+    const packageJson = JSON.parse(packageJsonContent);
+    packageJson.name = packageName;
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
     initSpinner.success({ text: `${npmInit} completed successfully.` });
   } catch (err) {
@@ -116,7 +140,9 @@ function initCommand(options) {
     console.error(err.message);
   }
 
-  const addTypeDeclaration = createSpinner("Adding type declaration...").start();
+  const addTypeDeclaration = createSpinner(
+    "Adding type declaration..."
+  ).start();
   try {
     const packageJsonPath = path.join(targetDir, "package.json");
     const packageJsonContent = fs.readFileSync(packageJsonPath, "utf8");
@@ -124,35 +150,45 @@ function initCommand(options) {
     packageJson.type = "module";
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
-    addTypeDeclaration.success({ text: "Added type declaration successfully." });
+    addTypeDeclaration.success({
+      text: "Added type declaration successfully.",
+    });
   } catch (err) {
     addTypeDeclaration.error({ text: "Error adding type declaration.\n" });
     console.error(err.message);
   }
 
-  const addDependencies = createSpinner("Adding dependency packages...").start();
+  const addDependencies = createSpinner(
+    "Adding dependency packages..."
+  ).start();
   try {
     const packageJsonPath = path.join(targetDir, "package.json");
     const packageJsonContent = fs.readFileSync(packageJsonPath, "utf8");
     const packageJson = JSON.parse(packageJsonContent);
     packageJson.dependencies = packageJson.dependencies || {};
-    
+
     templates[selectedTemplate].dependencies.forEach((dependency) => {
       packageJson.dependencies[`${dependency.name}`] = dependency.version;
     });
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
-    addDependencies.success({ text: "Added dependency packages successfully." });
+    addDependencies.success({
+      text: "Added dependency packages successfully.",
+    });
   } catch (err) {
     addDependencies.error("Error adding dependency packages.\n");
     console.error(err.message);
   }
 
-  const installDependencies = createSpinner("Installing dependency packages...").start();
+  const installDependencies = createSpinner(
+    "Installing dependency packages..."
+  ).start();
   try {
     execSync("npm i", { stdio: "ignore", cwd: targetDir });
 
-    installDependencies.success({ text: "Installed dependencies successfully." });
+    installDependencies.success({
+      text: "Installed dependencies successfully.",
+    });
   } catch (err) {
     installDependencies.error({ text: "Error installing dependencies.\n" });
     console.error(err);
@@ -160,7 +196,7 @@ function initCommand(options) {
 
   console.log(chalk.green.bold("\nSetup complete! To run your server:"));
   console.log(chalk.yellow("Run:"), chalk.white.bold("npm start"));
-};
+}
 
 const toolIntro = () => {
   console.log(

--- a/bin/index.js
+++ b/bin/index.js
@@ -128,26 +128,10 @@ function initCommand(options) {
   console.log("Starting server initialization...");
 
   const targetDir = process.cwd();
-  const parentDir = path.dirname(__dirname);
-  const templatePath = path.join(
-    parentDir,
-    "templates",
-    templates[selectedTemplate].name
-  );
+  const templatePath = path.join(__dirname, "../templates", selectedTemplate);
+
   const destinationPath = path.join(targetDir);
   const npmInit = chalk.yellow.bold("npm init");
-
-  // Initialize package.json
-  const initSpinner = createSpinner(`Running ${npmInit}...`).start();
-  try {
-    execSync("npm init -y", { stdio: "ignore", cwd: targetDir });
-
-    initSpinner.success({ text: `${npmInit} completed successfully.` });
-  } catch (err) {
-    initSpinner.error({ text: `Error running ${npmInit}:\n` });
-    console.error(err.message);
-    return;
-  }
 
   const copySpinner = createSpinner("Creating server files...").start();
   try {
@@ -159,44 +143,22 @@ function initCommand(options) {
     console.error(err.message);
   }
 
-  const addTypeDeclaration = createSpinner(
-    "Adding type declaration..."
+  const addNameAndTypeSpinner = createSpinner(
+    "Adding name and type declaration..."
   ).start();
   try {
     const packageJsonPath = path.join(targetDir, "package.json");
     const packageJsonContent = fs.readFileSync(packageJsonPath, "utf8");
     const packageJson = JSON.parse(packageJsonContent);
-    packageJson.name = packageName;
-    packageJson.type = "module";
+    packageJson.name = packageName; // Set custom package name
+    packageJson.type = "module"; // Define type as module
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
-    addTypeDeclaration.success({
-      text: "Added type declaration successfully.",
+    addNameAndTypeSpinner.success({
+      text: "Added name and type declaration successfully.",
     });
   } catch (err) {
-    addTypeDeclaration.error({ text: "Error adding type declaration.\n" });
-    console.error(err.message);
-  }
-
-  const addDependencies = createSpinner(
-    "Adding dependency packages..."
-  ).start();
-  try {
-    const packageJsonPath = path.join(targetDir, "package.json");
-    const packageJsonContent = fs.readFileSync(packageJsonPath, "utf8");
-    const packageJson = JSON.parse(packageJsonContent);
-    packageJson.dependencies = packageJson.dependencies || {};
-
-    templates[selectedTemplate].dependencies.forEach((dependency) => {
-      packageJson.dependencies[`${dependency.name}`] = dependency.version;
-    });
-    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
-
-    addDependencies.success({
-      text: "Added dependency packages successfully.",
-    });
-  } catch (err) {
-    addDependencies.error("Error adding dependency packages.\n");
+    addNameAndTypeSpinner.error({ text: "Error adding type declaration.\n" });
     console.error(err.message);
   }
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -131,7 +131,6 @@ function initCommand(options) {
   const templatePath = path.join(__dirname, "../templates", selectedTemplate);
 
   const destinationPath = path.join(targetDir);
-  const npmInit = chalk.yellow.bold("npm init");
 
   const copySpinner = createSpinner("Creating server files...").start();
   try {

--- a/bin/index.js
+++ b/bin/index.js
@@ -9,6 +9,7 @@ import figlet from "figlet";
 import chalk from "chalk";
 import { createSpinner } from "nanospinner";
 import { metadata, commands, templates } from "./configs.js";
+import validate from "validate-npm-package-name";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -91,10 +92,32 @@ function initCommand(options) {
   const selectedTemplate = options.template || "basic"; // Default to 'basic' if no template is specified
   const packageName = options.name || "quick-start-express-server"; // Default to 'quick-start-express-server' if no name is specified
 
+  if (packageName) {
+    const validateResult = validate(packageName);
+    if (validateResult.validForNewPackages === false) {
+      if (validateResult.errors) {
+        console.error(
+          chalk.red.bold(
+            `Invalid package name: ${validateResult.errors}. Please provide a valid package name.`
+          )
+        );
+      } else if (validateResult.warnings) {
+        console.error(
+          chalk.red.bold(
+            `Invalid package name: ${validateResult.warnings}. Please provide a valid package name.`
+          )
+        );
+      }
+      return;
+    }
+  }
+
   if (!templates[selectedTemplate]) {
     console.error(
-      chalk.bgRed.white(
-        `Template ${selectedTemplate} does not exist. To see available templates use "qse list".`
+      chalk.red(
+        `Template ${selectedTemplate} does not exist. To see available templates use ${chalk.yellow(
+          '"qse list"'
+        )}.`
       )
     );
     return;

--- a/bin/index.js
+++ b/bin/index.js
@@ -142,12 +142,6 @@ function initCommand(options) {
   try {
     execSync("npm init -y", { stdio: "ignore", cwd: targetDir });
 
-    const packageJsonPath = path.join(targetDir, "package.json");
-    const packageJsonContent = fs.readFileSync(packageJsonPath, "utf8");
-    const packageJson = JSON.parse(packageJsonContent);
-    packageJson.name = packageName;
-    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
-
     initSpinner.success({ text: `${npmInit} completed successfully.` });
   } catch (err) {
     initSpinner.error({ text: `Error running ${npmInit}:\n` });
@@ -172,6 +166,7 @@ function initCommand(options) {
     const packageJsonPath = path.join(targetDir, "package.json");
     const packageJsonContent = fs.readFileSync(packageJsonPath, "utf8");
     const packageJson = JSON.parse(packageJsonContent);
+    packageJson.name = packageName;
     packageJson.type = "module";
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "commander": "^12.1.0",
     "figlet": "^1.7.0",
     "fs-extra": "^11.2.0",
-    "nanospinner": "^1.1.0"
+    "nanospinner": "^1.1.0",
+    "validate-npm-package-name": "^6.0.0"
   },
   "devDependencies": {
     "jest": "^29.7.0"

--- a/templates/basic/package.json
+++ b/templates/basic/package.json
@@ -6,6 +6,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js"
   },
+  "type": "module",
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/templates/basic/package.json
+++ b/templates/basic/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "basic",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.17.1"
+  }
+}

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -71,7 +71,7 @@ describe('init', () => {
         await exec(`node ../../bin/index.js init`, { cwd: tempDir });
         const commandHash = computeSHA256Hash(tempDir);
         expect(commandHash).toEqual(originalHash);
-    })
+    });
 
     test('basic', async () => {
         const originalHash = computeSHA256Hash(path.join(__dirname, '..', 'templates', 'basic'));
@@ -95,7 +95,56 @@ describe('init', () => {
     }, 10000);
 
     test('invalid template name passed', async () => {
-        const { stdout, stderr } = await exec(`node ../../bin/index.js init -t invalid_name`, { cwd: tempDir });
-        expect(stripAnsi(stderr)).toContain(`Template invalid_name does not exist. To see available templates use "qse list".`);
+        const { stdout, stderr } = await exec(`node ../../bin/index.js init -t invalid_template`, { cwd: tempDir });
+        expect(stripAnsi(stderr)).toContain(`Template invalid_template does not exist. To see available templates use "qse list".`);
+    });
+
+    test('invalid template name: >214 characters', async () => {
+        const longName = 'a'.repeat(215);
+        const { stderr } = await exec(`node ../../bin/index.js init -n ${longName}`, { cwd: tempDir });
+        expect(stripAnsi(stderr)).toContain('Invalid package name: name can no longer contain more than 214 characters. Please provide a valid package name.');
+    });
+
+    test('invalid template name: contains uppercase characters', async () => {
+        const { stderr } = await exec(`node ../../bin/index.js init -n InvalidName`, { cwd: tempDir });
+        expect(stripAnsi(stderr)).toContain('Invalid package name: name can no longer contain capital letters. Please provide a valid package name.');
+    });
+
+    test('invalid template name: contains non URL friendly charcters', async () => {
+        const { stderr } = await exec(`node ../../bin/index.js init -n "#invalid name"`, { cwd: tempDir });
+        expect(stripAnsi(stderr)).toContain('Invalid package name: name can only contain URL-friendly characters. Please provide a valid package name.');
+    });
+
+    test('valid template name: <= 214 characters', async () => {
+        const validName = 'a'.repeat(214);
+        await exec(`node ../../bin/index.js init -t basic -n ${validName}`, { cwd: tempDir });
+
+        const packageJsonPath = path.join(tempDir, 'package.json');
+        const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
+        const packageJson = JSON.parse(packageJsonContent);
+
+        expect(packageJson.name).toBe(validName);
+    });
+
+    test('valid template name: lowercase only', async () => {
+        const validName = 'validname';
+        await exec(`node ../../bin/index.js init -n ${validName}`, { cwd: tempDir });
+
+        const packageJsonPath = path.join(tempDir, 'package.json');
+        const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
+        const packageJson = JSON.parse(packageJsonContent);
+
+        expect(packageJson.name).toBe(validName);
+    });
+
+    test('valid template name: URL friendly characters', async () => {
+        const validName = 'valid-name';
+        await exec(`node ../../bin/index.js init -n ${validName}`, { cwd: tempDir });
+
+        const packageJsonPath = path.join(tempDir, 'package.json');
+        const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
+        const packageJson = JSON.parse(packageJsonContent);
+
+        expect(packageJson.name).toBe(validName);
     });
 });

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -4,6 +4,7 @@ const crypto = require('crypto');
 const util = require('node:util');
 const exec = util.promisify(require('node:child_process').exec);
 const tempDir = path.join(__dirname, 'temp');
+const stripAnsi = require('strip-ansi');
 
 function initTempDirectory() {
     if (fs.existsSync(tempDir)) {
@@ -95,6 +96,6 @@ describe('init', () => {
 
     test('invalid template name passed', async () => {
         const { stdout, stderr } = await exec(`node ../../bin/index.js init -t invalid_name`, { cwd: tempDir });
-        expect(stderr).toContain(`Template invalid_name does not exist. To see available templates use "qse list".`);
+        expect(stripAnsi(stderr)).toContain(`Template invalid_name does not exist. To see available templates use "qse list".`);
     });
 });

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -5,6 +5,7 @@ const list = `Available Commands:
 - -v, --version: Prints current qse version
 - init: Initialize a new Express server.
   (Options: -t, --template <template> - Specify template to use)
+  (Options: -n, --name <name> - Specify the name of the package)
 - list: List all available commands and options.
 - clear: Clear the directory.
 


### PR DESCRIPTION
# PR  : feat: add -n option to customize package name during initialization
This PR adds a new `-n` or `--name` option to the `init` command to set a custom name during initialization.
This addresses the issue #50 

### Features Added
- Added `-n, --name` option to the `init` command in `configs.js`.
- Updated `index.js` to get the `name` option and then update `package.json`.

