### PR TITLE
[COMPLETED] Add --no-dependencies Flag to Make Dependency Installation Optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ qse list
 ### Output
 
 <div align="center">
-   <img src="https://github.com/user-attachments/assets/c8ca7057-8ccc-4f6c-a152-992aeee68b7e" width="800px"/>
+   <img src="https://github.com/user-attachments/assets/6f36f0e1-c714-4728-bd81-844b8104fe43" width="800px"/>
 </div>
 
 ## Init
@@ -73,13 +73,14 @@ qse init --remove-nodemon
 
 Initialize without installation of dependencies.
 ```bash
-qse init --no-deps
+qse init --remove-deps
 ```
+
 
 ### Output
 
 <div align="center">
-   <img src="https://github.com/user-attachments/assets/44457d46-83d7-4392-8a28-0884c6609791" width="800px"/>
+   <img src="https://github.com/user-attachments/assets/6ad96031-ff06-469f-8ec0-319d812558fa" width="800px"/>
 </div>
 
 ## Clear

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Initialize without nodemon.
 qse init --remove-nodemon
 ```
 
+Initialize without installation of dependencies.
+```bash
+qse init --no-dependencies
+```
+
 ### Output
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ npm test
 - [Adripo](https://github.com/adripo)
 - [Akshay K S](https://github.com/akshayks13)
 - [K Venkatesh](https://github.com/venkatesh21bit)
+- [Vaibav](https://github.com/vaibav03)
 - [Phuong Thuy Nguyen](https://github.com/irisgranger)
 - [Abhinav Bansal](https://github.com/Abhinav-Bansal751)
 - [Guilherme Almeida Lopes](https://github.com/alguiguilo098)

--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ List all available commands and options.
 qse list
 ```
 
+
 ### Output
 
 <div align="center">
-   <img src="https://github.com/user-attachments/assets/75a53c79-de47-4e0f-b9eb-9b5ca5101481" width="800px"/>
+   <img src="https://github.com/user-attachments/assets/c8ca7057-8ccc-4f6c-a152-992aeee68b7e" width="800px"/>
 </div>
 
 ## Init
@@ -72,13 +73,14 @@ qse init --remove-nodemon
 
 Initialize without installation of dependencies.
 ```bash
-qse init --no-dependencies
+qse init --no-deps
 ```
+
 
 ### Output
 
 <div align="center">
-   <img src="https://github.com/user-attachments/assets/40eab11f-e36a-42be-b63a-c01a2ce486e0" width="800px"/>
+   <img src="https://github.com/user-attachments/assets/94c6c849-2ed2-4602-b471-07fe0dcf3a29" width="800px"/>
 </div>
 
 ## Clear

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ npm test
 - [Jayadev D](https://github.com/FLASH2332)
 - [K Venkatesh](https://github.com/venkatesh21bit)
 - [Vaibav](https://github.com/vaibav03)
+- [Pavan Prakash K](https://github.com/PavanCodes05)
 - [Phuong Thuy Nguyen](https://github.com/irisgranger)
 - [Abhinav Bansal](https://github.com/Abhinav-Bansal751)
 - [Guilherme Almeida Lopes](https://github.com/alguiguilo098)

--- a/README.md
+++ b/README.md
@@ -76,11 +76,10 @@ Initialize without installation of dependencies.
 qse init --no-deps
 ```
 
-
 ### Output
 
 <div align="center">
-   <img src="https://github.com/user-attachments/assets/94c6c849-2ed2-4602-b471-07fe0dcf3a29" width="800px"/>
+   <img src="https://github.com/user-attachments/assets/44457d46-83d7-4392-8a28-0884c6609791" width="800px"/>
 </div>
 
 ## Clear

--- a/bin/configs.js
+++ b/bin/configs.js
@@ -1,7 +1,7 @@
 export const metadata = {
   command: "qse",
   name: "Quick Start Express",
-  version: "v1.0.5-beta",
+  version: "v1.0.6-beta",
   description:
     "A simple CLI tool to generate Express servers from multiple available templates.",
   oneLineDescription: "A simple Express.js server generator CLI tool.",

--- a/bin/configs.js
+++ b/bin/configs.js
@@ -30,8 +30,8 @@ export const commands = {
       },
       {
         flags: "--remove-deps",
-        description: "Do not install the dependencies"
-      }
+        description: "Do not install the dependencies",
+      },
     ],
   },
   list: {

--- a/bin/configs.js
+++ b/bin/configs.js
@@ -29,7 +29,7 @@ export const commands = {
         description: "Disable hot-reload support using nodemon",
       },
       {
-        flags: "--no-deps",
+        flags: "--remove-deps",
         description: "Do not install the dependencies"
       }
     ],

--- a/bin/configs.js
+++ b/bin/configs.js
@@ -28,6 +28,10 @@ export const commands = {
         flags: "--remove-nodemon",
         description: "Disable hot-reload support using nodemon",
       },
+      {
+        flags: "--no-dependencies",
+        description: "Do not install the dependencies"
+      }
     ],
   },
   list: {

--- a/bin/configs.js
+++ b/bin/configs.js
@@ -29,7 +29,7 @@ export const commands = {
         description: "Disable hot-reload support using nodemon",
       },
       {
-        flags: "--no-dependencies",
+        flags: "--no-deps",
         description: "Do not install the dependencies"
       }
     ],

--- a/bin/index.js
+++ b/bin/index.js
@@ -209,20 +209,20 @@ async function initCommand(options) {
       console.error(err);
     }
   }
-
+  
   console.log(chalk.green.bold("\nSetup complete! To run your server:"));
+  if (!dependencies) {
+    console.log(
+      chalk.yellow("Install dependencies: "),
+      chalk.white.bold("npm i")
+    )
+  }
   console.log(chalk.yellow("Run:"), chalk.white.bold("npm start"));
   if (!removeNodemon) {
     console.log(
       chalk.yellow("Run with hot reloading:"),
       chalk.white.bold("npm run dev")
     );
-  }
-  if (!dependencies) {
-    console.log(
-      chalk.yellow("Install dependencies: "),
-      chalk.white.bold("npm i")
-    )
   }
 }
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -200,7 +200,7 @@ async function initCommand(options) {
     ).start();
     try {
       execSync("npm i", { stdio: "ignore", cwd: targetDir });
-  
+
       installDependencies.success({
         text: "Installed dependencies successfully.",
       });
@@ -209,13 +209,13 @@ async function initCommand(options) {
       console.error(err);
     }
   }
-  
+
   console.log(chalk.green.bold("\nSetup complete! To run your server:"));
   if (removeDependencies) {
     console.log(
       chalk.yellow("Install dependencies: "),
       chalk.white.bold("npm i")
-    )
+    );
   }
   console.log(chalk.yellow("Run:"), chalk.white.bold("npm start"));
   if (!removeNodemon) {

--- a/bin/index.js
+++ b/bin/index.js
@@ -95,7 +95,7 @@ async function initCommand(options) {
   const selectedTemplate = options.template || "basic"; // Default to 'basic' if no template is specified
   const packageName = options.name || "quick-start-express-server"; // Default to 'quick-start-express-server' if no name is specified
   const removeNodemon = options.removeNodemon;
-  const dependencies = options.dependencies
+  const dependencies = options.deps
 
   if (packageName) {
     const validateResult = validate(packageName);

--- a/bin/index.js
+++ b/bin/index.js
@@ -26,6 +26,7 @@ program
   .option(commands.init.options[0].flags, commands.init.options[0].description)
   .option(commands.init.options[1].flags, commands.init.options[1].description)
   .option(commands.init.options[2].flags, commands.init.options[2].description)
+  .option(commands.init.options[3].flags, commands.init.options[3].description)
   .action((options) => {
     toolIntro();
     initCommand(options);
@@ -94,6 +95,7 @@ async function initCommand(options) {
   const selectedTemplate = options.template || "basic"; // Default to 'basic' if no template is specified
   const packageName = options.name || "quick-start-express-server"; // Default to 'quick-start-express-server' if no name is specified
   const removeNodemon = options.removeNodemon;
+  const dependencies = options.dependencies
 
   if (packageName) {
     const validateResult = validate(packageName);
@@ -192,18 +194,20 @@ async function initCommand(options) {
     console.error(err.message);
   }
 
-  const installDependencies = createSpinner(
-    "Installing dependency packages..."
-  ).start();
-  try {
-    execSync("npm i", { stdio: "ignore", cwd: targetDir });
-
-    installDependencies.success({
-      text: "Installed dependencies successfully.",
-    });
-  } catch (err) {
-    installDependencies.error({ text: "Error installing dependencies.\n" });
-    console.error(err);
+  if (dependencies) {
+    const installDependencies = createSpinner(
+      "Installing dependency packages..."
+    ).start();
+    try {
+      execSync("npm i", { stdio: "ignore", cwd: targetDir });
+  
+      installDependencies.success({
+        text: "Installed dependencies successfully.",
+      });
+    } catch (err) {
+      installDependencies.error({ text: "Error installing dependencies.\n" });
+      console.error(err);
+    }
   }
 
   console.log(chalk.green.bold("\nSetup complete! To run your server:"));

--- a/bin/index.js
+++ b/bin/index.js
@@ -95,7 +95,7 @@ async function initCommand(options) {
   const selectedTemplate = options.template || "basic"; // Default to 'basic' if no template is specified
   const packageName = options.name || "quick-start-express-server"; // Default to 'quick-start-express-server' if no name is specified
   const removeNodemon = options.removeNodemon;
-  const dependencies = options.deps
+  const removeDependencies = options.removeDeps;
 
   if (packageName) {
     const validateResult = validate(packageName);
@@ -194,7 +194,7 @@ async function initCommand(options) {
     console.error(err.message);
   }
 
-  if (dependencies) {
+  if (!removeDependencies) {
     const installDependencies = createSpinner(
       "Installing dependency packages..."
     ).start();
@@ -211,7 +211,7 @@ async function initCommand(options) {
   }
   
   console.log(chalk.green.bold("\nSetup complete! To run your server:"));
-  if (!dependencies) {
+  if (removeDependencies) {
     console.log(
       chalk.yellow("Install dependencies: "),
       chalk.white.bold("npm i")

--- a/bin/index.js
+++ b/bin/index.js
@@ -218,6 +218,12 @@ async function initCommand(options) {
       chalk.white.bold("npm run dev")
     );
   }
+  if (!dependencies) {
+    console.log(
+      chalk.yellow("Install dependencies: "),
+      chalk.white.bold("npm i")
+    )
+  }
 }
 
 const toolIntro = () => {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "node bin/index.js init",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+    "test": "node --experimental-vm-modules --disable-warning=ExperimentalWarning node_modules/jest/bin/jest.js --verbose"
   },
   "author": "Abhinav Ramakrishnan, Ashwin Narayanan S",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qse",
-  "version": "1.0.5-beta",
+  "version": "1.0.6-beta",
   "description": "A simple CLI tool to generate Express servers from multiple available templates.",
   "type": "module",
   "main": "index.js",

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -18,7 +18,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const tempDir = path.join(__dirname, "temp");
 
 function readPackageJson() {
-  const packageJsonPath = path.join(tempDir, 'package.json');
+  const packageJsonPath = path.join(tempDir, "package.json");
   const packageJsonContent = readFileSync(packageJsonPath, "utf8");
   return JSON.parse(packageJsonContent);
 }
@@ -33,7 +33,7 @@ function hasNodemon() {
     return false;
   }
 
-  if (!packageJson.scripts.dev.includes('nodemon')) {
+  if (!packageJson.scripts.dev.includes("nodemon")) {
     return false;
   }
 
@@ -67,7 +67,7 @@ function clearTempDirectory() {
 }
 
 function nodeModulesExist() {
-  return existsSync(path.join(tempDir, 'node_modules'));
+  return existsSync(path.join(tempDir, "node_modules"));
 }
 
 function traverseDirectory(dirName, hash) {
@@ -216,7 +216,7 @@ describe("normal init with default settings", () => {
     expect(hasNodemon()).toBe(true);
     expect(nodeModulesExist()).toBe(true);
   }, 20000);
-})
+});
 
 describe("init --remove-deps", () => {
   beforeEach(() => {
@@ -243,7 +243,9 @@ describe("init --remove-deps", () => {
     const originalHash = computeSHA256Hash(
       path.join(__dirname, "..", "templates", "basic")
     );
-    await exec(`node ../../bin/index.js init -t basic --remove-deps`, { cwd: tempDir });
+    await exec(`node ../../bin/index.js init -t basic --remove-deps`, {
+      cwd: tempDir,
+    });
     const commandHash = computeSHA256Hash(tempDir);
     expect(commandHash).toEqual(originalHash);
 
@@ -255,9 +257,12 @@ describe("init --remove-deps", () => {
     const originalHash = computeSHA256Hash(
       path.join(__dirname, "..", "templates", "express_pg_sequelize")
     );
-    await exec(`node ../../bin/index.js init -t express_pg_sequelize --remove-deps`, {
-      cwd: tempDir,
-    });
+    await exec(
+      `node ../../bin/index.js init -t express_pg_sequelize --remove-deps`,
+      {
+        cwd: tempDir,
+      }
+    );
     const commandHash = computeSHA256Hash(tempDir);
     expect(commandHash).toEqual(originalHash);
 
@@ -283,9 +288,12 @@ describe("init --remove-deps", () => {
     const originalHash = computeSHA256Hash(
       path.join(__dirname, "..", "templates", "express_oauth_microsoft")
     );
-    await exec(`node ../../bin/index.js init -t express_oauth_microsoft --remove-deps`, {
-      cwd: tempDir,
-    });
+    await exec(
+      `node ../../bin/index.js init -t express_oauth_microsoft --remove-deps`,
+      {
+        cwd: tempDir,
+      }
+    );
     const commandHash = computeSHA256Hash(tempDir);
     expect(commandHash).toEqual(originalHash);
 
@@ -297,9 +305,12 @@ describe("init --remove-deps", () => {
     const originalHash = computeSHA256Hash(
       path.join(__dirname, "..", "templates", "express_pg_prisma")
     );
-    await exec(`node ../../bin/index.js init -t express_pg_prisma --remove-deps`, {
-      cwd: tempDir,
-    });
+    await exec(
+      `node ../../bin/index.js init -t express_pg_prisma --remove-deps`,
+      {
+        cwd: tempDir,
+      }
+    );
     const commandHash = computeSHA256Hash(tempDir);
     expect(commandHash).toEqual(originalHash);
 
@@ -311,9 +322,12 @@ describe("init --remove-deps", () => {
     const originalHash = computeSHA256Hash(
       path.join(__dirname, "..", "templates", "express_oauth_google")
     );
-    await exec(`node ../../bin/index.js init -t express_oauth_google --remove-deps`, {
-      cwd: tempDir,
-    });
+    await exec(
+      `node ../../bin/index.js init -t express_oauth_google --remove-deps`,
+      {
+        cwd: tempDir,
+      }
+    );
     const commandHash = computeSHA256Hash(tempDir);
     expect(commandHash).toEqual(originalHash);
 
@@ -375,9 +389,12 @@ describe("init with custom template name without installing deps", () => {
 
   test("valid template name: <= 214 characters", async () => {
     const validName = "a".repeat(214);
-    await exec(`node ../../bin/index.js init -t basic -n ${validName} --remove-deps`, {
-      cwd: tempDir,
-    });
+    await exec(
+      `node ../../bin/index.js init -t basic -n ${validName} --remove-deps`,
+      {
+        cwd: tempDir,
+      }
+    );
     verifyPackageName(validName);
   }, 20000);
 
@@ -396,7 +413,7 @@ describe("init with custom template name without installing deps", () => {
     });
     verifyPackageName(validName);
   }, 20000);
-})
+});
 
 // Not installing dependencies for faster tests.
 describe("init without nodemon option without installing deps.", () => {
@@ -408,87 +425,107 @@ describe("init without nodemon option without installing deps.", () => {
     clearTempDirectory();
   });
 
-  test('no template passed, should default to basic template without nodemon', async () => {
-    await exec('node ../../bin/index.js init --remove-nodemon --remove-deps', { cwd: tempDir });
+  test("no template passed, should default to basic template without nodemon", async () => {
+    await exec("node ../../bin/index.js init --remove-nodemon --remove-deps", {
+      cwd: tempDir,
+    });
     const packageJson = readPackageJson();
 
-    expect(packageJson.scripts.start).not.toContain('nodemon');
+    expect(packageJson.scripts.start).not.toContain("nodemon");
     expect(packageJson.scripts.dev).toBeUndefined();
 
     if (packageJson.devDependencies) {
-      expect(packageJson.devDependencies).not.toHaveProperty('nodemon');
+      expect(packageJson.devDependencies).not.toHaveProperty("nodemon");
     }
   }, 20000);
 
-  test('basic without nodemon', async () => {
-    await exec('node ../../bin/index.js init -t basic --remove-nodemon --remove-deps', { cwd: tempDir });
+  test("basic without nodemon", async () => {
+    await exec(
+      "node ../../bin/index.js init -t basic --remove-nodemon --remove-deps",
+      { cwd: tempDir }
+    );
     const packageJson = readPackageJson();
 
-    expect(packageJson.scripts.start).not.toContain('nodemon');
+    expect(packageJson.scripts.start).not.toContain("nodemon");
     expect(packageJson.scripts.dev).toBeUndefined();
 
     if (packageJson.devDependencies) {
-      expect(packageJson.devDependencies).not.toHaveProperty('nodemon');
+      expect(packageJson.devDependencies).not.toHaveProperty("nodemon");
     }
   }, 20000);
 
-  test('express_pg_sequelize without nodemon', async () => {
-    await exec('node ../../bin/index.js init -t express_pg_sequelize --remove-nodemon --remove-deps', { cwd: tempDir, });
+  test("express_pg_sequelize without nodemon", async () => {
+    await exec(
+      "node ../../bin/index.js init -t express_pg_sequelize --remove-nodemon --remove-deps",
+      { cwd: tempDir }
+    );
     const packageJson = readPackageJson();
 
-    expect(packageJson.scripts.start).not.toContain('nodemon');
+    expect(packageJson.scripts.start).not.toContain("nodemon");
     expect(packageJson.scripts.dev).toBeUndefined();
 
     if (packageJson.devDependencies) {
-      expect(packageJson.devDependencies).not.toHaveProperty('nodemon');
+      expect(packageJson.devDependencies).not.toHaveProperty("nodemon");
     }
   }, 20000);
 
-  test('express_mysql without nodemon', async () => {
-    await exec('node ../../bin/index.js init -t express_mysql --remove-nodemon --remove-deps', { cwd: tempDir, });
+  test("express_mysql without nodemon", async () => {
+    await exec(
+      "node ../../bin/index.js init -t express_mysql --remove-nodemon --remove-deps",
+      { cwd: tempDir }
+    );
     const packageJson = readPackageJson();
 
-    expect(packageJson.scripts.start).not.toContain('nodemon');
+    expect(packageJson.scripts.start).not.toContain("nodemon");
     expect(packageJson.scripts.dev).toBeUndefined();
 
     if (packageJson.devDependencies) {
-      expect(packageJson.devDependencies).not.toHaveProperty('nodemon');
+      expect(packageJson.devDependencies).not.toHaveProperty("nodemon");
     }
   }, 20000);
 
-  test('express_oauth_microsoft without nodemon', async () => {
-    await exec('node ../../bin/index.js init -t express_oauth_microsoft --remove-nodemon --remove-deps', { cwd: tempDir, });
+  test("express_oauth_microsoft without nodemon", async () => {
+    await exec(
+      "node ../../bin/index.js init -t express_oauth_microsoft --remove-nodemon --remove-deps",
+      { cwd: tempDir }
+    );
     const packageJson = readPackageJson();
 
-    expect(packageJson.scripts.start).not.toContain('nodemon');
+    expect(packageJson.scripts.start).not.toContain("nodemon");
     expect(packageJson.scripts.dev).toBeUndefined();
 
     if (packageJson.devDependencies) {
-      expect(packageJson.devDependencies).not.toHaveProperty('nodemon');
+      expect(packageJson.devDependencies).not.toHaveProperty("nodemon");
     }
   }, 20000);
 
-  test('express_pg_prisma without nodemon', async () => {
-    await exec('node ../../bin/index.js init -t express_pg_prisma --remove-nodemon --remove-deps', { cwd: tempDir, });
+  test("express_pg_prisma without nodemon", async () => {
+    await exec(
+      "node ../../bin/index.js init -t express_pg_prisma --remove-nodemon --remove-deps",
+      { cwd: tempDir }
+    );
     const packageJson = readPackageJson();
 
-    expect(packageJson.scripts.start).not.toContain('nodemon');
+    expect(packageJson.scripts.start).not.toContain("nodemon");
     expect(packageJson.scripts.dev).toBeUndefined();
 
     if (packageJson.devDependencies) {
-      expect(packageJson.devDependencies).not.toHaveProperty('nodemon');
+      expect(packageJson.devDependencies).not.toHaveProperty("nodemon");
     }
   }, 20000);
 
-  test('express_oauth_google without nodemon', async () => {
-    await exec('node ../../bin/index.js init -t express_oauth_google --remove-nodemon --remove-deps', { cwd: tempDir, });
+  test("express_oauth_google without nodemon", async () => {
+    await exec(
+      "node ../../bin/index.js init -t express_oauth_google --remove-nodemon --remove-deps",
+      { cwd: tempDir }
+    );
     const packageJson = readPackageJson();
 
-    expect(packageJson.scripts.start).not.toContain('nodemon');
+    expect(packageJson.scripts.start).not.toContain("nodemon");
     expect(packageJson.scripts.dev).toBeUndefined();
 
     if (packageJson.devDependencies) {
-      expect(packageJson.devDependencies).not.toHaveProperty('nodemon');
+      expect(packageJson.devDependencies).not.toHaveProperty("nodemon");
     }
   }, 20000);
-})
+});

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -66,6 +66,10 @@ function clearTempDirectory() {
   }
 }
 
+function nodeModulesExist() {
+  return existsSync(path.join(tempDir, 'node_modules'));
+}
+
 function traverseDirectory(dirName, hash) {
   const files = readdirSync(dirName);
 
@@ -108,7 +112,9 @@ function computeSHA256Hash(dirName) {
   return hash.digest("hex");
 }
 
-describe("init", () => {
+// Verify if installing dependencies is happening by default
+// along with nodemon in package.json bby default.
+describe("normal init with default settings", () => {
   beforeEach(() => {
     initTempDirectory();
   });
@@ -126,7 +132,8 @@ describe("init", () => {
     expect(commandHash).toEqual(originalHash);
 
     expect(hasNodemon()).toBe(true);
-  }, 10000);
+    expect(nodeModulesExist()).toBe(true);
+  }, 20000);
 
   test("basic with nodemon", async () => {
     const originalHash = computeSHA256Hash(
@@ -137,7 +144,8 @@ describe("init", () => {
     expect(commandHash).toEqual(originalHash);
 
     expect(hasNodemon()).toBe(true);
-  }, 10000);
+    expect(nodeModulesExist()).toBe(true);
+  }, 20000);
 
   test("express_pg_sequelize with nodemon", async () => {
     const originalHash = computeSHA256Hash(
@@ -150,7 +158,8 @@ describe("init", () => {
     expect(commandHash).toEqual(originalHash);
 
     expect(hasNodemon()).toBe(true);
-  }, 10000);
+    expect(nodeModulesExist()).toBe(true);
+  }, 20000);
 
   test("express_mysql with nodemon", async () => {
     const originalHash = computeSHA256Hash(
@@ -163,7 +172,8 @@ describe("init", () => {
     expect(commandHash).toEqual(originalHash);
 
     expect(hasNodemon()).toBe(true);
-  }, 10000);
+    expect(nodeModulesExist()).toBe(true);
+  }, 20000);
 
   test("express_oauth_microsoft with nodemon", async () => {
     const originalHash = computeSHA256Hash(
@@ -176,7 +186,8 @@ describe("init", () => {
     expect(commandHash).toEqual(originalHash);
 
     expect(hasNodemon()).toBe(true);
-  }, 10000);
+    expect(nodeModulesExist()).toBe(true);
+  }, 20000);
 
   test("express_pg_prisma with nodemon", async () => {
     const originalHash = computeSHA256Hash(
@@ -189,8 +200,9 @@ describe("init", () => {
     expect(commandHash).toEqual(originalHash);
 
     expect(hasNodemon()).toBe(true);
-  }, 15000);
-  
+    expect(nodeModulesExist()).toBe(true);
+  }, 20000);
+
   test("express_oauth_google with nodemon", async () => {
     const originalHash = computeSHA256Hash(
       path.join(__dirname, "..", "templates", "express_oauth_google")
@@ -202,11 +214,127 @@ describe("init", () => {
     expect(commandHash).toEqual(originalHash);
 
     expect(hasNodemon()).toBe(true);
-  }, 10000);
+    expect(nodeModulesExist()).toBe(true);
+  }, 20000);
+})
+
+describe("init --remove-deps", () => {
+  beforeEach(() => {
+    initTempDirectory();
+  });
+
+  afterAll(() => {
+    clearTempDirectory();
+  });
+
+  test("no templates passed, should default to basic with nodemon without deps installed", async () => {
+    const originalHash = computeSHA256Hash(
+      path.join(__dirname, "..", "templates", "basic")
+    );
+    await exec(`node ../../bin/index.js init --remove-deps`, { cwd: tempDir });
+    const commandHash = computeSHA256Hash(tempDir);
+    expect(commandHash).toEqual(originalHash);
+
+    expect(hasNodemon()).toBe(true);
+    expect(nodeModulesExist()).toBe(false);
+  }, 20000);
+
+  test("basic with nodemon without deps installed", async () => {
+    const originalHash = computeSHA256Hash(
+      path.join(__dirname, "..", "templates", "basic")
+    );
+    await exec(`node ../../bin/index.js init -t basic --remove-deps`, { cwd: tempDir });
+    const commandHash = computeSHA256Hash(tempDir);
+    expect(commandHash).toEqual(originalHash);
+
+    expect(hasNodemon()).toBe(true);
+    expect(nodeModulesExist()).toBe(false);
+  }, 20000);
+
+  test("express_pg_sequelize with nodemon without deps installed", async () => {
+    const originalHash = computeSHA256Hash(
+      path.join(__dirname, "..", "templates", "express_pg_sequelize")
+    );
+    await exec(`node ../../bin/index.js init -t express_pg_sequelize --remove-deps`, {
+      cwd: tempDir,
+    });
+    const commandHash = computeSHA256Hash(tempDir);
+    expect(commandHash).toEqual(originalHash);
+
+    expect(hasNodemon()).toBe(true);
+    expect(nodeModulesExist()).toBe(false);
+  }, 20000);
+
+  test("express_mysql with nodemon without deps installed", async () => {
+    const originalHash = computeSHA256Hash(
+      path.join(__dirname, "..", "templates", "express_mysql")
+    );
+    await exec(`node ../../bin/index.js init -t express_mysql --remove-deps`, {
+      cwd: tempDir,
+    });
+    const commandHash = computeSHA256Hash(tempDir);
+    expect(commandHash).toEqual(originalHash);
+
+    expect(hasNodemon()).toBe(true);
+    expect(nodeModulesExist()).toBe(false);
+  }, 20000);
+
+  test("express_oauth_microsoft with nodemon without deps installed", async () => {
+    const originalHash = computeSHA256Hash(
+      path.join(__dirname, "..", "templates", "express_oauth_microsoft")
+    );
+    await exec(`node ../../bin/index.js init -t express_oauth_microsoft --remove-deps`, {
+      cwd: tempDir,
+    });
+    const commandHash = computeSHA256Hash(tempDir);
+    expect(commandHash).toEqual(originalHash);
+
+    expect(hasNodemon()).toBe(true);
+    expect(nodeModulesExist()).toBe(false);
+  }, 20000);
+
+  test("express_pg_prisma with nodemon without deps installed", async () => {
+    const originalHash = computeSHA256Hash(
+      path.join(__dirname, "..", "templates", "express_pg_prisma")
+    );
+    await exec(`node ../../bin/index.js init -t express_pg_prisma --remove-deps`, {
+      cwd: tempDir,
+    });
+    const commandHash = computeSHA256Hash(tempDir);
+    expect(commandHash).toEqual(originalHash);
+
+    expect(hasNodemon()).toBe(true);
+    expect(nodeModulesExist()).toBe(false);
+  }, 20000);
+
+  test("express_oauth_google with nodemon without deps installed", async () => {
+    const originalHash = computeSHA256Hash(
+      path.join(__dirname, "..", "templates", "express_oauth_google")
+    );
+    await exec(`node ../../bin/index.js init -t express_oauth_google --remove-deps`, {
+      cwd: tempDir,
+    });
+    const commandHash = computeSHA256Hash(tempDir);
+    expect(commandHash).toEqual(originalHash);
+
+    expect(hasNodemon()).toBe(true);
+    expect(nodeModulesExist()).toBe(false);
+  }, 20000);
+});
+
+// Not installing dependencies as it takes time and is already tested above.
+describe("init with custom template name without installing deps", () => {
+  beforeEach(() => {
+    initTempDirectory();
+  });
+
+  afterAll(() => {
+    clearTempDirectory();
+  });
 
   test("invalid template name passed", async () => {
     const { stdout, stderr } = await exec(
-      `node ../../bin/index.js init -t invalid_template`,
+      `node ../../bin/index.js init -t invalid_template --remove-deps`,
       { cwd: tempDir }
     );
     expect(stripAnsi(stderr)).toContain(
@@ -217,7 +345,7 @@ describe("init", () => {
   test("invalid template name: >214 characters", async () => {
     const longName = "a".repeat(215);
     const { stderr } = await exec(
-      `node ../../bin/index.js init -n ${longName}`,
+      `node ../../bin/index.js init -n ${longName} --remove-deps`,
       { cwd: tempDir }
     );
     expect(stripAnsi(stderr)).toContain(
@@ -227,7 +355,7 @@ describe("init", () => {
 
   test("invalid template name: contains uppercase characters", async () => {
     const { stderr } = await exec(
-      `node ../../bin/index.js init -n InvalidName`,
+      `node ../../bin/index.js init -n InvalidName --remove-deps`,
       { cwd: tempDir }
     );
     expect(stripAnsi(stderr)).toContain(
@@ -237,7 +365,7 @@ describe("init", () => {
 
   test("invalid template name: contains non URL friendly charcters", async () => {
     const { stderr } = await exec(
-      `node ../../bin/index.js init -n "#invalid name%"`,
+      `node ../../bin/index.js init -n "#invalid name%" --remove-deps`,
       { cwd: tempDir }
     );
     expect(stripAnsi(stderr)).toContain(
@@ -247,31 +375,41 @@ describe("init", () => {
 
   test("valid template name: <= 214 characters", async () => {
     const validName = "a".repeat(214);
-    await exec(`node ../../bin/index.js init -t basic -n ${validName}`, {
+    await exec(`node ../../bin/index.js init -t basic -n ${validName} --remove-deps`, {
       cwd: tempDir,
     });
     verifyPackageName(validName);
-  }, 10000);
+  }, 20000);
 
   test("valid template name: lowercase only", async () => {
     const validName = "validname";
-    await exec(`node ../../bin/index.js init -n ${validName}`, {
+    await exec(`node ../../bin/index.js init -n ${validName} --remove-deps`, {
       cwd: tempDir,
     });
     verifyPackageName(validName);
-  }, 10000);
+  }, 20000);
 
   test("valid template name: URL friendly characters", async () => {
     const validName = "valid-name";
-    await exec(`node ../../bin/index.js init -n ${validName}`, {
+    await exec(`node ../../bin/index.js init -n ${validName} --remove-deps`, {
       cwd: tempDir,
     });
     verifyPackageName(validName);
-  }, 10000);
+  }, 20000);
+})
 
-  // Nodemon flag tests.
+// Not installing dependencies for faster tests.
+describe("init without nodemon option without installing deps.", () => {
+  beforeEach(() => {
+    initTempDirectory();
+  });
+
+  afterAll(() => {
+    clearTempDirectory();
+  });
+
   test('no template passed, should default to basic template without nodemon', async () => {
-    await exec('node ../../bin/index.js init --remove-nodemon', { cwd: tempDir });
+    await exec('node ../../bin/index.js init --remove-nodemon --remove-deps', { cwd: tempDir });
     const packageJson = readPackageJson();
 
     expect(packageJson.scripts.start).not.toContain('nodemon');
@@ -280,10 +418,10 @@ describe("init", () => {
     if (packageJson.devDependencies) {
       expect(packageJson.devDependencies).not.toHaveProperty('nodemon');
     }
-  }, 10000);
+  }, 20000);
 
   test('basic without nodemon', async () => {
-    await exec('node ../../bin/index.js init -t basic --remove-nodemon', { cwd: tempDir });
+    await exec('node ../../bin/index.js init -t basic --remove-nodemon --remove-deps', { cwd: tempDir });
     const packageJson = readPackageJson();
 
     expect(packageJson.scripts.start).not.toContain('nodemon');
@@ -292,10 +430,10 @@ describe("init", () => {
     if (packageJson.devDependencies) {
       expect(packageJson.devDependencies).not.toHaveProperty('nodemon');
     }
-  }, 10000);
+  }, 20000);
 
   test('express_pg_sequelize without nodemon', async () => {
-    await exec('node ../../bin/index.js init -t express_pg_sequelize --remove-nodemon', { cwd: tempDir, });
+    await exec('node ../../bin/index.js init -t express_pg_sequelize --remove-nodemon --remove-deps', { cwd: tempDir, });
     const packageJson = readPackageJson();
 
     expect(packageJson.scripts.start).not.toContain('nodemon');
@@ -304,10 +442,10 @@ describe("init", () => {
     if (packageJson.devDependencies) {
       expect(packageJson.devDependencies).not.toHaveProperty('nodemon');
     }
-  }, 10000);
+  }, 20000);
 
   test('express_mysql without nodemon', async () => {
-    await exec('node ../../bin/index.js init -t express_mysql --remove-nodemon', { cwd: tempDir, });
+    await exec('node ../../bin/index.js init -t express_mysql --remove-nodemon --remove-deps', { cwd: tempDir, });
     const packageJson = readPackageJson();
 
     expect(packageJson.scripts.start).not.toContain('nodemon');
@@ -316,10 +454,10 @@ describe("init", () => {
     if (packageJson.devDependencies) {
       expect(packageJson.devDependencies).not.toHaveProperty('nodemon');
     }
-  }, 10000);
+  }, 20000);
 
   test('express_oauth_microsoft without nodemon', async () => {
-    await exec('node ../../bin/index.js init -t express_oauth_microsoft --remove-nodemon', { cwd: tempDir, });
+    await exec('node ../../bin/index.js init -t express_oauth_microsoft --remove-nodemon --remove-deps', { cwd: tempDir, });
     const packageJson = readPackageJson();
 
     expect(packageJson.scripts.start).not.toContain('nodemon');
@@ -328,10 +466,10 @@ describe("init", () => {
     if (packageJson.devDependencies) {
       expect(packageJson.devDependencies).not.toHaveProperty('nodemon');
     }
-  }, 10000);
+  }, 20000);
 
   test('express_pg_prisma without nodemon', async () => {
-    await exec('node ../../bin/index.js init -t express_pg_prisma --remove-nodemon', { cwd: tempDir, });
+    await exec('node ../../bin/index.js init -t express_pg_prisma --remove-nodemon --remove-deps', { cwd: tempDir, });
     const packageJson = readPackageJson();
 
     expect(packageJson.scripts.start).not.toContain('nodemon');
@@ -340,10 +478,10 @@ describe("init", () => {
     if (packageJson.devDependencies) {
       expect(packageJson.devDependencies).not.toHaveProperty('nodemon');
     }
-  }, 15000);
+  }, 20000);
 
   test('express_oauth_google without nodemon', async () => {
-    await exec('node ../../bin/index.js init -t express_oauth_google --remove-nodemon', { cwd: tempDir, });
+    await exec('node ../../bin/index.js init -t express_oauth_google --remove-nodemon --remove-deps', { cwd: tempDir, });
     const packageJson = readPackageJson();
 
     expect(packageJson.scripts.start).not.toContain('nodemon');
@@ -352,5 +490,5 @@ describe("init", () => {
     if (packageJson.devDependencies) {
       expect(packageJson.devDependencies).not.toHaveProperty('nodemon');
     }
-  }, 10000);
-});
+  }, 20000);
+})

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -18,7 +18,7 @@ Available Templates:
 - express_mysql
 - express_pg_prisma
 - express_oauth_microsoft
-- express_oauth_google\n`
+- express_oauth_google\n`;
 
 describe("List Command", () => {
   test("list", async () => {

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -8,6 +8,7 @@ const list = `Available Commands:
   (Options: -t, --template <template> - Specify template to use)
   (Options: -n, --name <name> - Specify the name of the package)
   (Options: --remove-nodemon - Disable hot-reload support using nodemon)
+  (Options: --remove-deps - Do not install the dependencies)
 - list: List all available commands and options.
 - clear: Clear the directory.
 


### PR DESCRIPTION
Issue #68 : 

This PR introduces a new feature that allows users to skip the installation of dependencies when generating an Express template using the quick-start-express CLI.

Previously, the dependencies were installed by default after the template was generated, which might not always align with the user's workflow or preferences. With the addition of the --no-dependencies flag, users now have the flexibility to control whether dependencies are installed during the template setup.

@Ashrockzzz2003 