### PR TITLE
[WIP] - Add tests for qse init command with docker-compose flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,3 +251,4 @@ npm test
 - [Guilherme Almeida Lopes](https://github.com/alguiguilo098)
 - [Nitansh Shankar](https://github.com/BIJJUDAMA)
 - [Priyansh Narang](https://github.com/priyansh-narang2308)
+- [afmireski](https://github.com/afmireski)

--- a/bin/configs.js
+++ b/bin/configs.js
@@ -43,7 +43,8 @@ export const commands = {
             },
             {
                 flags: "--no-db",
-                description: "Remove db images from Docker Compose templates that need them.",
+                description:
+                    "Remove db images from Docker Compose templates that need them.",
             },
         ],
     },

--- a/bin/configs.js
+++ b/bin/configs.js
@@ -8,6 +8,14 @@ export const metadata = {
         "Welcome to QSE: A simple Express.js server generator CLI tool.",
 };
 
+export const supportedDockerComposeCacheImages = [
+    "redis:latest",
+    "redis:6.2",
+    "redis:7.0",
+    "memcached:latest",
+    "amazon/aws-elasticache:redis",
+];
+
 export const commands = {
     version: {
         command: "-v, --version",
@@ -30,21 +38,22 @@ export const commands = {
                 description: "Generate a Docker Compose file in the project.",
             },
             {
+                flags: `--cache-service <skip|name>`,
+                description:
+                    "Specify the cache service to add to the Docker Compose file or 'skip' to skip it.",
+            },
+            {
+                flags: "--skip-db",
+                description:
+                    "Specify whether to skip or add database images to the Docker Compose file.",
+            },
+            {
                 flags: "--remove-nodemon",
                 description: "Disable hot-reload support using nodemon",
             },
             {
                 flags: "--remove-deps",
                 description: "Do not install the dependencies",
-            },
-            {
-                flags: "--add-cache-service",
-                description: "Add a cache service to the Docker Compose file.",
-            },
-            {
-                flags: "--no-db",
-                description:
-                    "Remove db images from Docker Compose templates that need them.",
             },
         ],
     },

--- a/bin/configs.js
+++ b/bin/configs.js
@@ -41,6 +41,10 @@ export const commands = {
                 flags: "--add-cache-service",
                 description: "Add a cache service to the Docker Compose file.",
             },
+            {
+                flags: "--no-db",
+                description: "Remove db images from Docker Compose templates that need them.",
+            },
         ],
     },
     list: {

--- a/bin/configs.js
+++ b/bin/configs.js
@@ -37,6 +37,10 @@ export const commands = {
                 flags: "--remove-deps",
                 description: "Do not install the dependencies",
             },
+            {
+                flags: "--add-cache-service",
+                description: "Add a cache service to the Docker Compose file.",
+            },
         ],
     },
     list: {

--- a/bin/index.js
+++ b/bin/index.js
@@ -50,6 +50,10 @@ program
         commands.init.options[4].flags,
         commands.init.options[4].description,
     )
+    .option(
+        commands.init.options[5].flags,
+        commands.init.options[5].description,
+    )
     .action((options) => {
         toolIntro();
         initCommand(options);
@@ -102,6 +106,7 @@ async function initCommand(options) {
     const removeNodemon = options.removeNodemon;
     const removeDependencies = options.removeDeps;
     const dockerCompose = options.dockerCompose;
+    const addCacheService = options.addCacheService;    
 
     if (!options.template) {
         initMenu(initCommand);
@@ -175,7 +180,7 @@ async function initCommand(options) {
                 packageName,
                 selectedTemplate,
                 runtimeNeedDB,
-                userPrompt.addCacheService,
+                addCacheService,
             );
 
             console.log("Starting server initialization...");

--- a/bin/index.js
+++ b/bin/index.js
@@ -185,7 +185,7 @@ async function initCommand(options) {
                 packageName,
                 selectedTemplate,
                 runtimeNeedDB,
-                addCacheService,
+                addCacheService, // Original implementation: userPrompt.addCacheService,
             );
 
             console.log("Starting server initialization...");

--- a/bin/index.js
+++ b/bin/index.js
@@ -110,9 +110,8 @@ async function initCommand(options) {
     const removeNodemon = options.removeNodemon;
     const removeDependencies = options.removeDeps;
     const dockerCompose = options.dockerCompose;
-    const addCacheService = options.addCacheService; 
+    const addCacheService = options.addCacheService;
     const addDb = options.db;
-    
 
     if (!options.template) {
         initMenu(initCommand);

--- a/bin/index.js
+++ b/bin/index.js
@@ -54,6 +54,10 @@ program
         commands.init.options[5].flags,
         commands.init.options[5].description,
     )
+    .option(
+        commands.init.options[6].flags,
+        commands.init.options[6].description,
+    )
     .action((options) => {
         toolIntro();
         initCommand(options);
@@ -106,7 +110,9 @@ async function initCommand(options) {
     const removeNodemon = options.removeNodemon;
     const removeDependencies = options.removeDeps;
     const dockerCompose = options.dockerCompose;
-    const addCacheService = options.addCacheService;    
+    const addCacheService = options.addCacheService; 
+    const addDb = options.db;
+    
 
     if (!options.template) {
         initMenu(initCommand);
@@ -149,7 +155,7 @@ async function initCommand(options) {
     );
 
     const isUrl = templates[selectedTemplate].isUrl;
-    const needDB = templates[selectedTemplate].needDB;
+    const needDB = templates[selectedTemplate].needDB && addDb;
     let runtimeNeedDB = false;
 
     let dockerTemplate =

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { program } from "commander";
+import { Option, program } from "commander";
 import fs from "fs-extra";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -8,7 +8,12 @@ import { execSync } from "child_process";
 import figlet from "figlet";
 import chalk from "chalk";
 import { createSpinner } from "nanospinner";
-import { metadata, commands, templates } from "./configs.js";
+import {
+    metadata,
+    commands,
+    templates,
+    supportedDockerComposeCacheImages,
+} from "./configs.js";
 import validate from "validate-npm-package-name";
 import {
     getServicesData,
@@ -42,9 +47,13 @@ program
         commands.init.options[2].flags,
         commands.init.options[2].description,
     )
-    .option(
-        commands.init.options[3].flags,
-        commands.init.options[3].description,
+    .addOption(
+        // Option is used to automatically generate the help message
+        // and to validate the input.
+        new Option(
+            commands.init.options[3].flags,
+            commands.init.options[3].description,
+        ).choices(supportedDockerComposeCacheImages.concat("skip")),
     )
     .option(
         commands.init.options[4].flags,
@@ -109,14 +118,16 @@ async function initCommand(options) {
     const packageName = options.name || "qse-server"; // Default to 'qse-server' if no name is specified
     const removeNodemon = options.removeNodemon;
     const removeDependencies = options.removeDeps;
-    const dockerCompose = options.dockerCompose;
-    const addCacheService = options.addCacheService;
-    const addDb = options.db;
 
     if (!options.template) {
-        initMenu(initCommand);
+        initMenu(initCommand, options);
         return;
     }
+
+    // Docker Compose options.
+    const dockerCompose = options.dockerCompose;
+    const cacheService = options.cacheService;
+    const skipDb = options.skipDb || false;
 
     if (packageName) {
         const validateResult = validate(packageName);
@@ -154,8 +165,7 @@ async function initCommand(options) {
     );
 
     const isUrl = templates[selectedTemplate].isUrl;
-    const needDB = templates[selectedTemplate].needDB && addDb;
-    let runtimeNeedDB = false;
+    const needDB = templates[selectedTemplate].needDB && !skipDb;
 
     let dockerTemplate =
         selectedTemplate.split("_")[0] === "express" ||
@@ -174,18 +184,19 @@ async function initCommand(options) {
     const destinationPath = path.join(targetDir);
     const dockerFileDestination = path.join(destinationPath, "Dockerfile");
 
+    let runtimeNeedDB = false;
     if (dockerCompose) {
         try {
-            const userPrompt = await userPrompts(needDB);
-            if (needDB) {
-                runtimeNeedDB = userPrompt.runtimeNeedDB;
-            }
+            console.log();
+            const userPrompt = await userPrompts(needDB, cacheService);
+            runtimeNeedDB = userPrompt.runtimeNeedDB;
 
             const serviceData = await getServicesData(
                 packageName,
                 selectedTemplate,
                 runtimeNeedDB,
-                addCacheService, // Original implementation: userPrompt.addCacheService,
+                userPrompt.addCacheService,
+                cacheService,
             );
 
             console.log("Starting server initialization...");
@@ -212,6 +223,7 @@ async function initCommand(options) {
             return;
         }
     } else {
+        console.log();
         console.log("Starting server initialization...");
     }
 

--- a/bin/util/docker.js
+++ b/bin/util/docker.js
@@ -12,12 +12,7 @@ export async function userPrompts(needDB) {
         });
     }
 
-    const addCacheService = await confirm({
-        message: "Do you want to add a cache service? (Default: No)",
-        default: false,
-    });
-
-    return { runtimeNeedDB, addCacheService };
+    return { runtimeNeedDB };
 }
 
 async function promptCacheService(packageName) {

--- a/bin/util/docker.js
+++ b/bin/util/docker.js
@@ -12,7 +12,13 @@ export async function userPrompts(needDB) {
         });
     }
 
-    return { runtimeNeedDB };
+    // const addCacheService = await confirm({
+    //     message: "Do you want to add a cache service? (Default: No)",
+    //     default: false,
+    // });
+
+    return { runtimeNeedDB/* , addCacheService */ };
+
 }
 
 async function promptCacheService(packageName) {

--- a/bin/util/docker.js
+++ b/bin/util/docker.js
@@ -17,8 +17,7 @@ export async function userPrompts(needDB) {
     //     default: false,
     // });
 
-    return { runtimeNeedDB/* , addCacheService */ };
-
+    return { runtimeNeedDB /* , addCacheService */ };
 }
 
 async function promptCacheService(packageName) {

--- a/bin/util/menu.js
+++ b/bin/util/menu.js
@@ -2,10 +2,10 @@ import { select, input, confirm } from "@inquirer/prompts";
 import { templates } from "../configs.js";
 
 // `initMenu` function is used to prompt the user for input when the `init` command is run.
-export async function initMenu(initCommand) {
+export async function initMenu(initCommand, options) {
     console.log();
 
-    const selectedTemplate = await select({
+    options.template = await select({
         message: "Select a template to use (default: basic)",
         choices: Object.values(templates).map((template) => ({
             name: template.name,
@@ -14,37 +14,27 @@ export async function initMenu(initCommand) {
         default: "basic",
     });
 
-    const packageName = await input({
+    options.name = await input({
         message: "Enter a name for your server app (default: qse-server)",
         default: "qse-server",
     });
 
-    const addDockerCompose = await confirm({
+    options.dockerCompose = await confirm({
         message:
             "Do you want to generate a Docker Compose file? (default: Yes)",
         default: true,
     });
 
-    const needNodemon = await confirm({
+    options.removeNodemon = !(await confirm({
         message: "Do you want nodemon hot-reload support? (default: Yes)",
         default: true,
-    });
+    }));
 
-    const installDeps = await confirm({
+    options.removeDeps = !(await confirm({
         message:
             "Do you wish to install dependencies after template generation? (default: Yes)",
         default: true,
-    });
-
-    const options = {
-        template: selectedTemplate,
-        name: packageName,
-        removeNodemon: !needNodemon,
-        removeDeps: !installDeps,
-        dockerCompose: addDockerCompose,
-    };
-
-    console.log();
+    }));
 
     initCommand(options);
 }

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -101,9 +101,7 @@ function computeSHA256Hash(dirName) {
     ];
 
     for (const file of files) {
-        if (
-            ignoreFilesList.includes(file)
-        ) {
+        if (ignoreFilesList.includes(file)) {
             continue;
         }
         const filePath = path.join(dirName, file);

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -686,12 +686,12 @@ describe("init --docker-compose", () => {
         verifyDockerFiles();
     }, 20000);
 
-    test.skip("express_pg with docker configuration", async () => {
+    test("express_pg with docker configuration", async () => {
         const originalHash = computeSHA256Hash(
             path.join(__dirname, "..", "templates", "express_pg"),
         );
         await exec(
-            "node ../../bin/index.js init -t express_pg --docker-compose",
+            "node ../../bin/index.js init -t express_pg --docker-compose --no-db",
             {
                 cwd: tempDir,
             },
@@ -705,12 +705,12 @@ describe("init --docker-compose", () => {
         verifyDockerFiles();
     }, 20000);
 
-    test.skip("express_pg_sequelize with docker configuration", async () => {
+    test("express_pg_sequelize with docker configuration", async () => {
         const originalHash = computeSHA256Hash(
             path.join(__dirname, "..", "templates", "express_pg_sequelize"),
         );
         await exec(
-            "node ../../bin/index.js init -t express_pg_sequelize --docker-compose",
+            "node ../../bin/index.js init -t express_pg_sequelize --docker-compose --no-db",
             {
                 cwd: tempDir,
             },
@@ -724,12 +724,12 @@ describe("init --docker-compose", () => {
         verifyDockerFiles();
     }, 20000);
 
-    test.skip("express_mysql with docker configuration", async () => {
+    test("express_mysql with docker configuration", async () => {
         const originalHash = computeSHA256Hash(
             path.join(__dirname, "..", "templates", "express_mysql"),
         );
         await exec(
-            "node ../../bin/index.js init -t express_mysql --docker-compose",
+            "node ../../bin/index.js init -t express_mysql --docker-compose --no-db",
             {
                 cwd: tempDir,
             },
@@ -762,12 +762,12 @@ describe("init --docker-compose", () => {
         verifyDockerFiles();
     }, 20000);
 
-    test.skip("express_pg_prisma with docker configuration", async () => {
+    test("express_pg_prisma with docker configuration", async () => {
         const originalHash = computeSHA256Hash(
             path.join(__dirname, "..", "templates", "express_pg_prisma"),
         );
         await exec(
-            "node ../../bin/index.js init -t express_pg_prisma --docker-compose",
+            "node ../../bin/index.js init -t express_pg_prisma --docker-compose --no-db",
             {
                 cwd: tempDir,
             },
@@ -781,12 +781,12 @@ describe("init --docker-compose", () => {
         verifyDockerFiles();
     }, 20000);
 
-    test.skip("express_mongo with docker configuration", async () => {
+    test("express_mongo with docker configuration", async () => {
         const originalHash = computeSHA256Hash(
             path.join(__dirname, "..", "templates", "express_mongo"),
         );
         await exec(
-            "node ../../bin/index.js init -t express_mongo --docker-compose",
+            "node ../../bin/index.js init -t express_mongo --docker-compose --no-db",
             {
                 cwd: tempDir,
             },

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -92,13 +92,17 @@ function computeSHA256Hash(dirName) {
     const hash = createHash("sha256");
     const files = readdirSync(dirName);
 
+    const ignoreFilesList = [
+        "node_modules",
+        "package-lock.json",
+        "package.json",
+        "docker-compose.yml",
+        "Dockerfile",
+    ];
+
     for (const file of files) {
         if (
-            file === "node_modules" ||
-            file === "package-lock.json" ||
-            file === "package.json" ||
-            file === "docker-compose.yml" ||
-            file === "Dockerfile"
+            ignoreFilesList.includes(file)
         ) {
             continue;
         }
@@ -682,7 +686,7 @@ describe("init --docker-compose", () => {
         verifyDockerFiles();
     }, 20000);
 
-    test("express_pg with docker configuration", async () => {
+    test.skip("express_pg with docker configuration", async () => {
         const originalHash = computeSHA256Hash(
             path.join(__dirname, "..", "templates", "express_pg"),
         );
@@ -701,7 +705,7 @@ describe("init --docker-compose", () => {
         verifyDockerFiles();
     }, 20000);
 
-    test("express_pg_sequelize with docker configuration", async () => {
+    test.skip("express_pg_sequelize with docker configuration", async () => {
         const originalHash = computeSHA256Hash(
             path.join(__dirname, "..", "templates", "express_pg_sequelize"),
         );
@@ -720,7 +724,7 @@ describe("init --docker-compose", () => {
         verifyDockerFiles();
     }, 20000);
 
-    test("express_mysql with docker configuration", async () => {
+    test.skip("express_mysql with docker configuration", async () => {
         const originalHash = computeSHA256Hash(
             path.join(__dirname, "..", "templates", "express_mysql"),
         );
@@ -758,7 +762,7 @@ describe("init --docker-compose", () => {
         verifyDockerFiles();
     }, 20000);
 
-    test("express_pg_prisma with docker configuration", async () => {
+    test.skip("express_pg_prisma with docker configuration", async () => {
         const originalHash = computeSHA256Hash(
             path.join(__dirname, "..", "templates", "express_pg_prisma"),
         );
@@ -777,7 +781,7 @@ describe("init --docker-compose", () => {
         verifyDockerFiles();
     }, 20000);
 
-    test("express_mongo with docker configuration", async () => {
+    test.skip("express_mongo with docker configuration", async () => {
         const originalHash = computeSHA256Hash(
             path.join(__dirname, "..", "templates", "express_mongo"),
         );

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -96,7 +96,9 @@ function computeSHA256Hash(dirName) {
         if (
             file === "node_modules" ||
             file === "package-lock.json" ||
-            file === "package.json"
+            file === "package.json" ||
+            file === "docker-compose.yml" ||
+            file === "Dockerfile"
         ) {
             continue;
         }
@@ -643,3 +645,192 @@ describe("init without nodemon option without installing deps.", () => {
 });
 
 // TODO: Add tests for docker-compose.
+
+function verifyDockerFiles() {
+    const dockerComposePath = path.join(tempDir, "docker-compose.yml");
+    const dockerfilePath = path.join(tempDir, "Dockerfile");
+
+    const existsBothDockerfiles =
+        existsSync(dockerComposePath) && existsSync(dockerfilePath);
+
+    expect(existsBothDockerfiles).toBe(true);
+}
+
+// TODO: Add tests for docker-compose.
+describe("init --docker-compose", () => {
+    beforeEach(() => {
+        initTempDirectory();
+    });
+
+    afterAll(() => {
+        clearTempDirectory();
+    });
+
+    test("basic with docker configuration", async () => {
+        const originalHash = computeSHA256Hash(
+            path.join(__dirname, "..", "templates", "basic"),
+        );
+        await exec("node ../../bin/index.js init -t basic --docker-compose", {
+            cwd: tempDir,
+        });
+
+        const commandHash = computeSHA256Hash(tempDir);
+        expect(commandHash).toEqual(originalHash);
+        expect(hasNodemon()).toBe(true);
+        expect(nodeModulesExist()).toBe(true);
+
+        verifyDockerFiles();
+    }, 20000);
+
+    test("express_pg with docker configuration", async () => {
+        const originalHash = computeSHA256Hash(
+            path.join(__dirname, "..", "templates", "express_pg"),
+        );
+        await exec(
+            "node ../../bin/index.js init -t express_pg --docker-compose",
+            {
+                cwd: tempDir,
+            },
+        );
+
+        const commandHash = computeSHA256Hash(tempDir);
+        expect(commandHash).toEqual(originalHash);
+        expect(hasNodemon()).toBe(true);
+        expect(nodeModulesExist()).toBe(true);
+
+        verifyDockerFiles();
+    }, 20000);
+
+    test("express_pg_sequelize with docker configuration", async () => {
+        const originalHash = computeSHA256Hash(
+            path.join(__dirname, "..", "templates", "express_pg_sequelize"),
+        );
+        await exec(
+            "node ../../bin/index.js init -t express_pg_sequelize --docker-compose",
+            {
+                cwd: tempDir,
+            },
+        );
+
+        const commandHash = computeSHA256Hash(tempDir);
+        expect(commandHash).toEqual(originalHash);
+        expect(hasNodemon()).toBe(true);
+        expect(nodeModulesExist()).toBe(true);
+
+        verifyDockerFiles();
+    }, 20000);
+
+    test("express_mysql with docker configuration", async () => {
+        const originalHash = computeSHA256Hash(
+            path.join(__dirname, "..", "templates", "express_mysql"),
+        );
+        await exec(
+            "node ../../bin/index.js init -t express_mysql --docker-compose",
+            {
+                cwd: tempDir,
+            },
+        );
+
+        const commandHash = computeSHA256Hash(tempDir);
+        expect(commandHash).toEqual(originalHash);
+        expect(hasNodemon()).toBe(true);
+        expect(nodeModulesExist()).toBe(true);
+
+        verifyDockerFiles();
+    }, 20000);
+
+    test("express_oauth_microsoft with docker configuration", async () => {
+        const originalHash = computeSHA256Hash(
+            path.join(__dirname, "..", "templates", "express_oauth_microsoft"),
+        );
+        await exec(
+            "node ../../bin/index.js init -t express_oauth_microsoft --docker-compose",
+            {
+                cwd: tempDir,
+            },
+        );
+
+        const commandHash = computeSHA256Hash(tempDir);
+        expect(commandHash).toEqual(originalHash);
+        expect(hasNodemon()).toBe(true);
+        expect(nodeModulesExist()).toBe(true);
+
+        verifyDockerFiles();
+    }, 20000);
+
+    test("express_pg_prisma with docker configuration", async () => {
+        const originalHash = computeSHA256Hash(
+            path.join(__dirname, "..", "templates", "express_pg_prisma"),
+        );
+        await exec(
+            "node ../../bin/index.js init -t express_pg_prisma --docker-compose",
+            {
+                cwd: tempDir,
+            },
+        );
+
+        const commandHash = computeSHA256Hash(tempDir);
+        expect(commandHash).toEqual(originalHash);
+        expect(hasNodemon()).toBe(true);
+        expect(nodeModulesExist()).toBe(true);
+
+        verifyDockerFiles();
+    }, 20000);
+
+    test("express_mongo with docker configuration", async () => {
+        const originalHash = computeSHA256Hash(
+            path.join(__dirname, "..", "templates", "express_mongo"),
+        );
+        await exec(
+            "node ../../bin/index.js init -t express_mongo --docker-compose",
+            {
+                cwd: tempDir,
+            },
+        );
+
+        const commandHash = computeSHA256Hash(tempDir);
+        expect(commandHash).toEqual(originalHash);
+        expect(hasNodemon()).toBe(true);
+        expect(nodeModulesExist()).toBe(true);
+
+        verifyDockerFiles();
+    }, 20000);
+
+    test("express_oauth_google with docker configuration", async () => {
+        const originalHash = computeSHA256Hash(
+            path.join(__dirname, "..", "templates", "express_oauth_google"),
+        );
+        await exec(
+            "node ../../bin/index.js init -t express_oauth_google --docker-compose",
+            {
+                cwd: tempDir,
+            },
+        );
+
+        const commandHash = computeSHA256Hash(tempDir);
+        expect(commandHash).toEqual(originalHash);
+        expect(hasNodemon()).toBe(true);
+        expect(nodeModulesExist()).toBe(true);
+
+        verifyDockerFiles();
+    }, 20000);
+
+    test("basic_ts with docker configuration", async () => {
+        const originalHash = computeSHA256Hash(
+            path.join(__dirname, "..", "templates", "basic_ts"),
+        );
+        await exec(
+            "node ../../bin/index.js init -t basic_ts --docker-compose",
+            {
+                cwd: tempDir,
+            },
+        );
+
+        const commandHash = computeSHA256Hash(tempDir);
+        expect(commandHash).toEqual(originalHash);
+        expect(hasNodemon()).toBe(true);
+        expect(nodeModulesExist()).toBe(true);
+
+        verifyDockerFiles();
+    }, 20000);
+});

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -117,6 +117,16 @@ function computeSHA256Hash(dirName) {
     return hash.digest("hex");
 }
 
+function verifyDockerFiles() {
+    const dockerComposePath = path.join(tempDir, "docker-compose.yml");
+    const dockerfilePath = path.join(tempDir, "Dockerfile");
+
+    const existsBothDockerfiles =
+        existsSync(dockerComposePath) && existsSync(dockerfilePath);
+
+    expect(existsBothDockerfiles).toBe(true);
+}
+
 // Verify if installing dependencies is happening by default
 // along with nodemon in package.json by default.
 describe("normal init with default settings", () => {
@@ -646,20 +656,7 @@ describe("init without nodemon option without installing deps.", () => {
     }, 20000);
 });
 
-// TODO: Add tests for docker-compose.
-
-function verifyDockerFiles() {
-    const dockerComposePath = path.join(tempDir, "docker-compose.yml");
-    const dockerfilePath = path.join(tempDir, "Dockerfile");
-
-    const existsBothDockerfiles =
-        existsSync(dockerComposePath) && existsSync(dockerfilePath);
-
-    expect(existsBothDockerfiles).toBe(true);
-}
-
-// TODO: Add tests for docker-compose.
-describe("init --docker-compose", () => {
+describe("init with docker-compose without cache service and db", () => {
     beforeEach(() => {
         initTempDirectory();
     });
@@ -672,14 +669,17 @@ describe("init --docker-compose", () => {
         const originalHash = computeSHA256Hash(
             path.join(__dirname, "..", "templates", "basic"),
         );
-        await exec("node ../../bin/index.js init -t basic --docker-compose", {
-            cwd: tempDir,
-        });
+        await exec(
+            "node ../../bin/index.js init -t basic --remove-deps --docker-compose --cache-service skip",
+            {
+                cwd: tempDir,
+            },
+        );
 
         const commandHash = computeSHA256Hash(tempDir);
         expect(commandHash).toEqual(originalHash);
         expect(hasNodemon()).toBe(true);
-        expect(nodeModulesExist()).toBe(true);
+        expect(nodeModulesExist()).toBe(false);
 
         verifyDockerFiles();
     }, 20000);
@@ -689,7 +689,7 @@ describe("init --docker-compose", () => {
             path.join(__dirname, "..", "templates", "express_pg"),
         );
         await exec(
-            "node ../../bin/index.js init -t express_pg --docker-compose --no-db",
+            "node ../../bin/index.js init -t express_pg --remove-deps --docker-compose --skip-db --cache-service skip",
             {
                 cwd: tempDir,
             },
@@ -698,7 +698,7 @@ describe("init --docker-compose", () => {
         const commandHash = computeSHA256Hash(tempDir);
         expect(commandHash).toEqual(originalHash);
         expect(hasNodemon()).toBe(true);
-        expect(nodeModulesExist()).toBe(true);
+        expect(nodeModulesExist()).toBe(false);
 
         verifyDockerFiles();
     }, 20000);
@@ -708,7 +708,7 @@ describe("init --docker-compose", () => {
             path.join(__dirname, "..", "templates", "express_pg_sequelize"),
         );
         await exec(
-            "node ../../bin/index.js init -t express_pg_sequelize --docker-compose --no-db",
+            "node ../../bin/index.js init -t express_pg_sequelize --remove-deps --docker-compose --skip-db --cache-service skip",
             {
                 cwd: tempDir,
             },
@@ -717,7 +717,7 @@ describe("init --docker-compose", () => {
         const commandHash = computeSHA256Hash(tempDir);
         expect(commandHash).toEqual(originalHash);
         expect(hasNodemon()).toBe(true);
-        expect(nodeModulesExist()).toBe(true);
+        expect(nodeModulesExist()).toBe(false);
 
         verifyDockerFiles();
     }, 20000);
@@ -727,7 +727,7 @@ describe("init --docker-compose", () => {
             path.join(__dirname, "..", "templates", "express_mysql"),
         );
         await exec(
-            "node ../../bin/index.js init -t express_mysql --docker-compose --no-db",
+            "node ../../bin/index.js init -t express_mysql --remove-deps --docker-compose --skip-db --cache-service skip",
             {
                 cwd: tempDir,
             },
@@ -736,7 +736,7 @@ describe("init --docker-compose", () => {
         const commandHash = computeSHA256Hash(tempDir);
         expect(commandHash).toEqual(originalHash);
         expect(hasNodemon()).toBe(true);
-        expect(nodeModulesExist()).toBe(true);
+        expect(nodeModulesExist()).toBe(false);
 
         verifyDockerFiles();
     }, 20000);
@@ -746,7 +746,7 @@ describe("init --docker-compose", () => {
             path.join(__dirname, "..", "templates", "express_oauth_microsoft"),
         );
         await exec(
-            "node ../../bin/index.js init -t express_oauth_microsoft --docker-compose",
+            "node ../../bin/index.js init -t express_oauth_microsoft --remove-deps --docker-compose --cache-service skip",
             {
                 cwd: tempDir,
             },
@@ -755,7 +755,7 @@ describe("init --docker-compose", () => {
         const commandHash = computeSHA256Hash(tempDir);
         expect(commandHash).toEqual(originalHash);
         expect(hasNodemon()).toBe(true);
-        expect(nodeModulesExist()).toBe(true);
+        expect(nodeModulesExist()).toBe(false);
 
         verifyDockerFiles();
     }, 20000);
@@ -765,7 +765,7 @@ describe("init --docker-compose", () => {
             path.join(__dirname, "..", "templates", "express_pg_prisma"),
         );
         await exec(
-            "node ../../bin/index.js init -t express_pg_prisma --docker-compose --no-db",
+            "node ../../bin/index.js init -t express_pg_prisma --remove-deps --docker-compose --skip-db --cache-service skip",
             {
                 cwd: tempDir,
             },
@@ -774,7 +774,7 @@ describe("init --docker-compose", () => {
         const commandHash = computeSHA256Hash(tempDir);
         expect(commandHash).toEqual(originalHash);
         expect(hasNodemon()).toBe(true);
-        expect(nodeModulesExist()).toBe(true);
+        expect(nodeModulesExist()).toBe(false);
 
         verifyDockerFiles();
     }, 20000);
@@ -784,7 +784,7 @@ describe("init --docker-compose", () => {
             path.join(__dirname, "..", "templates", "express_mongo"),
         );
         await exec(
-            "node ../../bin/index.js init -t express_mongo --docker-compose --no-db",
+            "node ../../bin/index.js init -t express_mongo --remove-deps --docker-compose --skip-db --cache-service skip",
             {
                 cwd: tempDir,
             },
@@ -793,7 +793,7 @@ describe("init --docker-compose", () => {
         const commandHash = computeSHA256Hash(tempDir);
         expect(commandHash).toEqual(originalHash);
         expect(hasNodemon()).toBe(true);
-        expect(nodeModulesExist()).toBe(true);
+        expect(nodeModulesExist()).toBe(false);
 
         verifyDockerFiles();
     }, 20000);
@@ -803,7 +803,7 @@ describe("init --docker-compose", () => {
             path.join(__dirname, "..", "templates", "express_oauth_google"),
         );
         await exec(
-            "node ../../bin/index.js init -t express_oauth_google --docker-compose",
+            "node ../../bin/index.js init -t express_oauth_google --remove-deps --docker-compose --cache-service skip",
             {
                 cwd: tempDir,
             },
@@ -812,7 +812,7 @@ describe("init --docker-compose", () => {
         const commandHash = computeSHA256Hash(tempDir);
         expect(commandHash).toEqual(originalHash);
         expect(hasNodemon()).toBe(true);
-        expect(nodeModulesExist()).toBe(true);
+        expect(nodeModulesExist()).toBe(false);
 
         verifyDockerFiles();
     }, 20000);
@@ -822,7 +822,7 @@ describe("init --docker-compose", () => {
             path.join(__dirname, "..", "templates", "basic_ts"),
         );
         await exec(
-            "node ../../bin/index.js init -t basic_ts --docker-compose",
+            "node ../../bin/index.js init -t basic_ts --remove-deps --docker-compose --cache-service skip",
             {
                 cwd: tempDir,
             },
@@ -831,8 +831,11 @@ describe("init --docker-compose", () => {
         const commandHash = computeSHA256Hash(tempDir);
         expect(commandHash).toEqual(originalHash);
         expect(hasNodemon()).toBe(true);
-        expect(nodeModulesExist()).toBe(true);
+        expect(nodeModulesExist()).toBe(false);
 
         verifyDockerFiles();
     }, 20000);
 });
+
+// TODO: Add tests for init with docker-compose with cache service specified.
+// TODO: Add tests for init with docker-compose with db enabled.

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -150,7 +150,7 @@ describe("normal init with default settings", () => {
 
         expect(hasNodemon()).toBe(true);
         expect(nodeModulesExist()).toBe(true);
-    }, 20000);
+    }, 25000);
 
     test("express_pg with nodemon", async () => {
         const originalHash = computeSHA256Hash(
@@ -164,7 +164,7 @@ describe("normal init with default settings", () => {
 
         expect(hasNodemon()).toBe(true);
         expect(nodeModulesExist()).toBe(true);
-    }, 20000);
+    }, 25000);
 
     test("express_pg_sequelize with nodemon", async () => {
         const originalHash = computeSHA256Hash(
@@ -178,7 +178,7 @@ describe("normal init with default settings", () => {
 
         expect(hasNodemon()).toBe(true);
         expect(nodeModulesExist()).toBe(true);
-    }, 20000);
+    }, 25000);
 
     test("express_mysql with nodemon", async () => {
         const originalHash = computeSHA256Hash(
@@ -192,7 +192,7 @@ describe("normal init with default settings", () => {
 
         expect(hasNodemon()).toBe(true);
         expect(nodeModulesExist()).toBe(true);
-    }, 20000);
+    }, 25000);
 
     test("express_oauth_microsoft with nodemon", async () => {
         const originalHash = computeSHA256Hash(
@@ -206,7 +206,7 @@ describe("normal init with default settings", () => {
 
         expect(hasNodemon()).toBe(true);
         expect(nodeModulesExist()).toBe(true);
-    }, 20000);
+    }, 25000);
 
     test("express_pg_prisma with nodemon", async () => {
         const originalHash = computeSHA256Hash(
@@ -220,7 +220,7 @@ describe("normal init with default settings", () => {
 
         expect(hasNodemon()).toBe(true);
         expect(nodeModulesExist()).toBe(true);
-    }, 20000);
+    }, 25000);
 
     test("express_mongo with nodemon", async () => {
         const originalHash = computeSHA256Hash(
@@ -234,7 +234,7 @@ describe("normal init with default settings", () => {
 
         expect(hasNodemon()).toBe(true);
         expect(nodeModulesExist()).toBe(true);
-    }, 20000);
+    }, 25000);
 
     test("express_oauth_google with nodemon", async () => {
         const originalHash = computeSHA256Hash(
@@ -248,7 +248,7 @@ describe("normal init with default settings", () => {
 
         expect(hasNodemon()).toBe(true);
         expect(nodeModulesExist()).toBe(true);
-    }, 20000);
+    }, 25000);
 
     test("basic_ts with nodemon", async () => {
         const originalHash = computeSHA256Hash(
@@ -262,7 +262,7 @@ describe("normal init with default settings", () => {
 
         expect(hasNodemon()).toBe(true);
         expect(nodeModulesExist()).toBe(true);
-    }, 20000);
+    }, 25000);
 });
 
 describe("init --remove-deps", () => {
@@ -288,7 +288,7 @@ describe("init --remove-deps", () => {
 
         expect(hasNodemon()).toBe(true);
         expect(nodeModulesExist()).toBe(false);
-    }, 20000);
+    }, 25000);
 
     test("express_pg with nodemon without deps installed", async () => {
         const originalHash = computeSHA256Hash(
@@ -302,7 +302,7 @@ describe("init --remove-deps", () => {
 
         expect(hasNodemon()).toBe(true);
         expect(nodeModulesExist()).toBe(false);
-    }, 20000);
+    }, 25000);
 
     test("express_pg_sequelize with nodemon without deps installed", async () => {
         const originalHash = computeSHA256Hash(
@@ -319,7 +319,7 @@ describe("init --remove-deps", () => {
 
         expect(hasNodemon()).toBe(true);
         expect(nodeModulesExist()).toBe(false);
-    }, 20000);
+    }, 25000);
 
     test("express_mysql with nodemon without deps installed", async () => {
         const originalHash = computeSHA256Hash(
@@ -336,7 +336,7 @@ describe("init --remove-deps", () => {
 
         expect(hasNodemon()).toBe(true);
         expect(nodeModulesExist()).toBe(false);
-    }, 20000);
+    }, 25000);
 
     test("express_oauth_microsoft with nodemon without deps installed", async () => {
         const originalHash = computeSHA256Hash(
@@ -353,7 +353,7 @@ describe("init --remove-deps", () => {
 
         expect(hasNodemon()).toBe(true);
         expect(nodeModulesExist()).toBe(false);
-    }, 20000);
+    }, 25000);
 
     test("express_pg_prisma with nodemon without deps installed", async () => {
         const originalHash = computeSHA256Hash(
@@ -370,7 +370,7 @@ describe("init --remove-deps", () => {
 
         expect(hasNodemon()).toBe(true);
         expect(nodeModulesExist()).toBe(false);
-    }, 20000);
+    }, 25000);
 
     test("express_mongo with nodemon without deps installed", async () => {
         const originalHash = computeSHA256Hash(
@@ -387,7 +387,7 @@ describe("init --remove-deps", () => {
 
         expect(hasNodemon()).toBe(true);
         expect(nodeModulesExist()).toBe(false);
-    }, 20000);
+    }, 25000);
 
     test("express_oauth_google with nodemon without deps installed", async () => {
         const originalHash = computeSHA256Hash(
@@ -404,7 +404,7 @@ describe("init --remove-deps", () => {
 
         expect(hasNodemon()).toBe(true);
         expect(nodeModulesExist()).toBe(false);
-    }, 20000);
+    }, 25000);
 
     test("basic_ts with nodemon without deps installed", async () => {
         const originalHash = computeSHA256Hash(
@@ -418,7 +418,7 @@ describe("init --remove-deps", () => {
 
         expect(hasNodemon()).toBe(true);
         expect(nodeModulesExist()).toBe(false);
-    }, 20000);
+    }, 25000);
 });
 
 // Not installing dependencies as it takes time and is already tested above.
@@ -481,7 +481,7 @@ describe("init with custom template name without installing deps", () => {
             },
         );
         verifyPackageName(validName);
-    }, 20000);
+    }, 25000);
 
     test("valid template name: lowercase only", async () => {
         const validName = "validname";
@@ -492,7 +492,7 @@ describe("init with custom template name without installing deps", () => {
             },
         );
         verifyPackageName(validName);
-    }, 20000);
+    }, 25000);
 
     test("valid template name: URL friendly characters", async () => {
         const validName = "valid-name";
@@ -503,7 +503,7 @@ describe("init with custom template name without installing deps", () => {
             },
         );
         verifyPackageName(validName);
-    }, 20000);
+    }, 25000);
 
     // TODO: Add test for cases where `inquirer` prompts are used for this.
 });
@@ -533,7 +533,7 @@ describe("init without nodemon option without installing deps.", () => {
         if (packageJson.devDependencies) {
             expect(packageJson.devDependencies).not.toHaveProperty("nodemon");
         }
-    }, 20000);
+    }, 25000);
 
     test("express_pg without nodemon", async () => {
         await exec(
@@ -548,7 +548,7 @@ describe("init without nodemon option without installing deps.", () => {
         if (packageJson.devDependencies) {
             expect(packageJson.devDependencies).not.toHaveProperty("nodemon");
         }
-    }, 20000);
+    }, 25000);
 
     test("express_pg_sequelize without nodemon", async () => {
         await exec(
@@ -563,7 +563,7 @@ describe("init without nodemon option without installing deps.", () => {
         if (packageJson.devDependencies) {
             expect(packageJson.devDependencies).not.toHaveProperty("nodemon");
         }
-    }, 20000);
+    }, 25000);
 
     test("express_mysql without nodemon", async () => {
         await exec(
@@ -578,7 +578,7 @@ describe("init without nodemon option without installing deps.", () => {
         if (packageJson.devDependencies) {
             expect(packageJson.devDependencies).not.toHaveProperty("nodemon");
         }
-    }, 20000);
+    }, 25000);
 
     test("express_oauth_microsoft without nodemon", async () => {
         await exec(
@@ -593,7 +593,7 @@ describe("init without nodemon option without installing deps.", () => {
         if (packageJson.devDependencies) {
             expect(packageJson.devDependencies).not.toHaveProperty("nodemon");
         }
-    }, 20000);
+    }, 25000);
 
     test("express_pg_prisma without nodemon", async () => {
         await exec(
@@ -608,7 +608,7 @@ describe("init without nodemon option without installing deps.", () => {
         if (packageJson.devDependencies) {
             expect(packageJson.devDependencies).not.toHaveProperty("nodemon");
         }
-    }, 20000);
+    }, 25000);
 
     test("express_mongo without nodemon", async () => {
         await exec(
@@ -623,7 +623,7 @@ describe("init without nodemon option without installing deps.", () => {
         if (packageJson.devDependencies) {
             expect(packageJson.devDependencies).not.toHaveProperty("nodemon");
         }
-    }, 20000);
+    }, 25000);
 
     test("express_oauth_google without nodemon", async () => {
         await exec(
@@ -638,7 +638,7 @@ describe("init without nodemon option without installing deps.", () => {
         if (packageJson.devDependencies) {
             expect(packageJson.devDependencies).not.toHaveProperty("nodemon");
         }
-    }, 20000);
+    }, 25000);
 
     test("basic_ts without nodemon", async () => {
         await exec(
@@ -653,7 +653,7 @@ describe("init without nodemon option without installing deps.", () => {
         if (packageJson.devDependencies) {
             expect(packageJson.devDependencies).not.toHaveProperty("nodemon");
         }
-    }, 20000);
+    }, 25000);
 });
 
 describe("init with docker-compose without cache service and db", () => {
@@ -682,7 +682,7 @@ describe("init with docker-compose without cache service and db", () => {
         expect(nodeModulesExist()).toBe(false);
 
         verifyDockerFiles();
-    }, 20000);
+    }, 25000);
 
     test("express_pg with docker configuration", async () => {
         const originalHash = computeSHA256Hash(
@@ -701,7 +701,7 @@ describe("init with docker-compose without cache service and db", () => {
         expect(nodeModulesExist()).toBe(false);
 
         verifyDockerFiles();
-    }, 20000);
+    }, 25000);
 
     test("express_pg_sequelize with docker configuration", async () => {
         const originalHash = computeSHA256Hash(
@@ -720,7 +720,7 @@ describe("init with docker-compose without cache service and db", () => {
         expect(nodeModulesExist()).toBe(false);
 
         verifyDockerFiles();
-    }, 20000);
+    }, 25000);
 
     test("express_mysql with docker configuration", async () => {
         const originalHash = computeSHA256Hash(
@@ -739,7 +739,7 @@ describe("init with docker-compose without cache service and db", () => {
         expect(nodeModulesExist()).toBe(false);
 
         verifyDockerFiles();
-    }, 20000);
+    }, 25000);
 
     test("express_oauth_microsoft with docker configuration", async () => {
         const originalHash = computeSHA256Hash(
@@ -758,7 +758,7 @@ describe("init with docker-compose without cache service and db", () => {
         expect(nodeModulesExist()).toBe(false);
 
         verifyDockerFiles();
-    }, 20000);
+    }, 25000);
 
     test("express_pg_prisma with docker configuration", async () => {
         const originalHash = computeSHA256Hash(
@@ -777,7 +777,7 @@ describe("init with docker-compose without cache service and db", () => {
         expect(nodeModulesExist()).toBe(false);
 
         verifyDockerFiles();
-    }, 20000);
+    }, 25000);
 
     test("express_mongo with docker configuration", async () => {
         const originalHash = computeSHA256Hash(
@@ -796,7 +796,7 @@ describe("init with docker-compose without cache service and db", () => {
         expect(nodeModulesExist()).toBe(false);
 
         verifyDockerFiles();
-    }, 20000);
+    }, 25000);
 
     test("express_oauth_google with docker configuration", async () => {
         const originalHash = computeSHA256Hash(
@@ -815,7 +815,7 @@ describe("init with docker-compose without cache service and db", () => {
         expect(nodeModulesExist()).toBe(false);
 
         verifyDockerFiles();
-    }, 20000);
+    }, 25000);
 
     test("basic_ts with docker configuration", async () => {
         const originalHash = computeSHA256Hash(
@@ -834,7 +834,7 @@ describe("init with docker-compose without cache service and db", () => {
         expect(nodeModulesExist()).toBe(false);
 
         verifyDockerFiles();
-    }, 20000);
+    }, 25000);
 });
 
 // TODO: Add tests for init with docker-compose with cache service specified.

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -13,6 +13,7 @@ const list = `Available Commands:
   (Options: --remove-nodemon - Disable hot-reload support using nodemon)
   (Options: --remove-deps - Do not install the dependencies)
   (Options: --add-cache-service - Add a cache service to the Docker Compose file.)
+  (Options: --no-db - Remove db images from Docker Compose templates that need them.)
 - list: List all available commands and options.
 - clear: Clear the directory.
 

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -10,10 +10,10 @@ const list = `Available Commands:
   (Options: -t, --template <template> - Specify template to use)
   (Options: -n, --name <name> - Specify the name of the package)
   (Options: --docker-compose - Generate a Docker Compose file in the project.)
+  (Options: --cache-service <skip|name> - Specify the cache service to add to the Docker Compose file or 'skip' to skip it.)
+  (Options: --skip-db - Specify whether to skip or add database images to the Docker Compose file.)
   (Options: --remove-nodemon - Disable hot-reload support using nodemon)
   (Options: --remove-deps - Do not install the dependencies)
-  (Options: --add-cache-service - Add a cache service to the Docker Compose file.)
-  (Options: --no-db - Remove db images from Docker Compose templates that need them.)
 - list: List all available commands and options.
 - clear: Clear the directory.
 

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -12,6 +12,7 @@ const list = `Available Commands:
   (Options: --docker-compose - Generate a Docker Compose file in the project.)
   (Options: --remove-nodemon - Disable hot-reload support using nodemon)
   (Options: --remove-deps - Do not install the dependencies)
+  (Options: --add-cache-service - Add a cache service to the Docker Compose file.)
 - list: List all available commands and options.
 - clear: Clear the directory.
 


### PR DESCRIPTION
Resolves #98 

### Description

Tests were implemented to verify the behavior of the --docker-compose flag in the init command.

Based on the discussions in the issue and the challenges faced by @alguiguilo098, I followed the suggestions and introduced a new flag: `--add-cache-service`.

Added the --no-db flag to allow bypassing the `needDb` prompt check in templates that had this option enabled.

- [x] All new an existing tests passed

Waiting @Ashrockzzz2003 review.